### PR TITLE
"Refresh theme" alpha.3 revisions

### DIFF
--- a/sites/sdcexec.com/config/gam.js
+++ b/sites/sdcexec.com/config/gam.js
@@ -18,7 +18,21 @@ config
       { viewport: [320, 0], size: [[300, 50], [320, 50]] },
     ],
   })
-  .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] });
+  .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] })
+  .setTemplate('INFINITE-RAIL', {
+    size: [[300, 250], [300, 600]],
+    sizeMapping: [
+      { viewport: [992, 0], size: [[300, 250], [300, 600]] },
+      { viewport: [0, 0], size: [] },
+    ],
+  })
+  .setTemplate('INFINITE-INTERSTITIAL', {
+    size: [[300, 250], [300, 600]],
+    sizeMapping: [
+      { viewport: [992, 0], size: [] },
+      { viewport: [300, 0], size: [[300, 250], [300, 600]] },
+    ],
+  });
 
 config
   .setAliasAdUnits('default', [
@@ -26,6 +40,8 @@ config
     { name: 'lb2', templateName: 'LB2', path: 'SDC_BS' },
     { name: 'rail1', templateName: 'CONTENT', path: 'SDC_MR' },
     { name: 'rail2', templateName: 'CONTENT', path: 'SDC_MR' },
+    { name: 'infinite-rail', templateName: 'INFINITE-RAIL', path: 'SDC_MR' },
+    { name: 'infinite-interstitial', templateName: 'INFINITE-INTERSTITIAL', path: 'SDC_MR' },
     { name: 'load-more', templateName: 'CONTENT', path: 'SDC_HP' },
     { name: 'reskin', path: 'SDC_Reskin' },
     { name: 'wa', path: 'SDC_WA' },

--- a/sites/sdcexec.com/config/gam.js
+++ b/sites/sdcexec.com/config/gam.js
@@ -11,12 +11,19 @@ config
       { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
     ],
   })
+  .setTemplate('LB2', {
+    size: [[320, 50], [300, 50]],
+    sizeMapping: [
+      { viewport: [576, 0], size: [] },
+      { viewport: [320, 0], size: [[300, 50], [320, 50]] },
+    ],
+  })
   .setTemplate('CONTENT', { size: [[300, 250], [300, 600]] });
 
 config
   .setAliasAdUnits('default', [
     { name: 'lb1', templateName: 'LB', path: 'SDC_BS' },
-    { name: 'lb2', templateName: 'LB', path: 'SDC_BS' },
+    { name: 'lb2', templateName: 'LB2', path: 'SDC_BS' },
     { name: 'rail1', templateName: 'CONTENT', path: 'SDC_MR' },
     { name: 'rail2', templateName: 'CONTENT', path: 'SDC_MR' },
     { name: 'load-more', templateName: 'CONTENT', path: 'SDC_HP' },

--- a/sites/sdcexec.com/config/gam.js
+++ b/sites/sdcexec.com/config/gam.js
@@ -11,7 +11,7 @@ config
       { viewport: [320, 0], size: [[300, 50], [320, 50], [300, 100]] },
     ],
   })
-  .setTemplate('LB2', {
+  .setTemplate('LB-STICKY-BOTTOM', {
     size: [[320, 50], [300, 50]],
     sizeMapping: [
       { viewport: [576, 0], size: [] },
@@ -37,7 +37,7 @@ config
 config
   .setAliasAdUnits('default', [
     { name: 'lb1', templateName: 'LB', path: 'SDC_BS' },
-    { name: 'lb2', templateName: 'LB2', path: 'SDC_BS' },
+    { name: 'lb-sticky-bottom', templateName: 'LB-STICKY-BOTTOM', path: 'SDC_BS' },
     { name: 'rail1', templateName: 'CONTENT', path: 'SDC_MR' },
     { name: 'rail2', templateName: 'CONTENT', path: 'SDC_MR' },
     { name: 'infinite-rail', templateName: 'INFINITE-RAIL', path: 'SDC_MR' },

--- a/sites/sdcexec.com/index.js
+++ b/sites/sdcexec.com/index.js
@@ -1,5 +1,6 @@
 const newrelic = require('newrelic');
 const { startServer } = require('@base-cms/marko-web');
+const cleanResponse = require('@base-cms/marko-core/middleware/clean-marko-response');
 const { version } = require('./package.json');
 const routes = require('./server/routes');
 const siteConfig = require('./config/site');
@@ -19,6 +20,10 @@ module.exports = startServer({
   components,
   fragments,
   version,
-  onStart: app => app.set('trust proxy', 'loopback, linklocal, uniquelocal'),
+  onStart: (app) => {
+    app.set('trust proxy', 'loopback, linklocal, uniquelocal');
+    // Clean all response bodies.
+    app.use(cleanResponse());
+  },
   onAsyncBlockError: e => newrelic.noticeError(e),
 }).then(() => log('Website started!')).catch(e => setImmediate(() => { throw e; }));

--- a/sites/sdcexec.com/server/components.js
+++ b/sites/sdcexec.com/server/components.js
@@ -2,10 +2,12 @@ const ContentCardDeckFlow = require('./components/flows/content-card-deck');
 const ContentLoadMoreFlow = require('./components/flows/content-load-more');
 const ContentListFlow = require('./components/flows/content-list');
 const MagazineIssueArchiveFlow = require('./components/flows/magazine-issue-archive');
+const LatestContentListFlow = require('./components/flows/latest-content-list');
 
 module.exports = {
   ContentCardDeckFlow,
   ContentLoadMoreFlow,
   ContentListFlow,
   MagazineIssueArchiveFlow,
+  LatestContentListFlow,
 };

--- a/sites/sdcexec.com/server/components/blocks/latest-content-load-more.marko
+++ b/sites/sdcexec.com/server/components/blocks/latest-content-load-more.marko
@@ -9,6 +9,7 @@ $ const page = getAsObject(input, "page");
   component-name="latest-content-list-flow"
   component-input={ withHeader: false, modifiers: ["infinite-scroll"] }
   fragment-name="content-list"
+  max-pages=input.maxPages
   query-name=query.name
   query-params=query.params
   page-input=page

--- a/sites/sdcexec.com/server/components/blocks/latest-content-load-more.marko
+++ b/sites/sdcexec.com/server/components/blocks/latest-content-load-more.marko
@@ -1,0 +1,15 @@
+import { getAsObject } from "@base-cms/object-path";
+
+$ const query = getAsObject(input, "query");
+$ const page = getAsObject(input, "page");
+
+<marko-web-load-more
+  append-to=".infinite-scroll-target"
+  expand=500
+  component-name="latest-content-list-flow"
+  component-input={ withHeader: false, modifiers: ["infinite-scroll"] }
+  fragment-name="content-list"
+  query-name=query.name
+  query-params=query.params
+  page-input=page
+/>

--- a/sites/sdcexec.com/server/components/blocks/latest-content-load-more.marko
+++ b/sites/sdcexec.com/server/components/blocks/latest-content-load-more.marko
@@ -7,7 +7,11 @@ $ const page = getAsObject(input, "page");
   append-to=".infinite-scroll-target"
   expand=500
   component-name="latest-content-list-flow"
-  component-input={ withHeader: false, modifiers: ["infinite-scroll"] }
+  component-input={
+    withHeader: false,
+    modifiers: ["infinite-scroll"],
+    adunit: input.adunit,
+  }
   fragment-name="content-list"
   max-pages=input.maxPages
   query-name=query.name

--- a/sites/sdcexec.com/server/components/blocks/marko.json
+++ b/sites/sdcexec.com/server/components/blocks/marko.json
@@ -3,6 +3,7 @@
     "template": "./latest-content-load-more.marko",
     "<query>": {},
     "<page>": {},
+    "<adunit>": {},
     "@max-pages": "number"
   },
   "<website-related-content-block>": {

--- a/sites/sdcexec.com/server/components/blocks/marko.json
+++ b/sites/sdcexec.com/server/components/blocks/marko.json
@@ -2,7 +2,8 @@
   "<website-latest-content-load-more-block>": {
     "template": "./latest-content-load-more.marko",
     "<query>": {},
-    "<page>": {}
+    "<page>": {},
+    "@max-pages": "number"
   },
   "<website-related-content-block>": {
     "template": "./related-content.marko",

--- a/sites/sdcexec.com/server/components/blocks/marko.json
+++ b/sites/sdcexec.com/server/components/blocks/marko.json
@@ -1,4 +1,9 @@
 {
+  "<website-latest-content-load-more-block>": {
+    "template": "./latest-content-load-more.marko",
+    "<query>": {},
+    "<page>": {}
+  },
   "<website-related-content-block>": {
     "template": "./related-content.marko",
     "<native-x>": {

--- a/sites/sdcexec.com/server/components/fixed-ad-bottom.marko
+++ b/sites/sdcexec.com/server/components/fixed-ad-bottom.marko
@@ -1,0 +1,7 @@
+import GAM from "../../config/gam";
+
+<marko-web-gam-fixed-ad-bottom
+  ...GAM.getAdUnit({ name: "lb-sticky-bottom", aliases: input.aliases })
+  refresh-interval=15
+  scroll-offset=100
+/>

--- a/sites/sdcexec.com/server/components/flows/latest-content-list.marko
+++ b/sites/sdcexec.com/server/components/flows/latest-content-list.marko
@@ -2,6 +2,7 @@ import { getAsArray, getAsObject } from "@base-cms/object-path";
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const nodes = getAsArray(input, "nodes");
+$ const header = defaultValue(input.header, "Latest");
 $ const withHeader = defaultValue(input.withHeader, false);
 $ const adunit = getAsObject(input, "adunit");
 
@@ -15,7 +16,7 @@ $ const adunit = getAsObject(input, "adunit");
   modifiers=["padding-large", ...getAsArray(input, "modifiers")]
 >
   <if(withHeader)>
-    <@header>Latest</@header>
+    <@header>${header}</@header>
   </if>
   <@node image-position="left" with-attribution=true with-teaser=true>
     <@image use-placeholder=false ar="16:9" width=288 />

--- a/sites/sdcexec.com/server/components/flows/latest-content-list.marko
+++ b/sites/sdcexec.com/server/components/flows/latest-content-list.marko
@@ -1,8 +1,13 @@
-import { getAsArray } from "@base-cms/object-path";
+import { getAsArray, getAsObject } from "@base-cms/object-path";
 import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const nodes = getAsArray(input, "nodes");
 $ const withHeader = defaultValue(input.withHeader, false);
+$ const adunit = getAsObject(input, "adunit");
+
+<if(adunit.path)>
+  <marko-web-gam-define-display-ad ...adunit class="mb-block" />
+</if>
 
 <website-content-list-flow
   nodes=nodes

--- a/sites/sdcexec.com/server/components/flows/latest-content-list.marko
+++ b/sites/sdcexec.com/server/components/flows/latest-content-list.marko
@@ -1,0 +1,18 @@
+import { getAsArray } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
+
+$ const nodes = getAsArray(input, "nodes");
+$ const withHeader = defaultValue(input.withHeader, false);
+
+<website-content-list-flow
+  nodes=nodes
+  inner-justified=false
+  modifiers=["padding-large", ...getAsArray(input, "modifiers")]
+>
+  <if(withHeader)>
+    <@header>Latest</@header>
+  </if>
+  <@node image-position="left" with-attribution=true with-teaser=true>
+    <@image use-placeholder=false ar="16:9" width=288 />
+  </@node>
+</website-content-list-flow>

--- a/sites/sdcexec.com/server/components/flows/marko.json
+++ b/sites/sdcexec.com/server/components/flows/marko.json
@@ -1,4 +1,10 @@
 {
+  "<website-latest-content-list-flow>": {
+    "template": "./latest-content-list.marko",
+    "@nodes": "array",
+    "@with-header": "boolean",
+    "@modifiers": "array"
+  },
   "<website-content-hero-flow>": {
     "template": "./content-hero.marko",
     "<list>": {},

--- a/sites/sdcexec.com/server/components/flows/marko.json
+++ b/sites/sdcexec.com/server/components/flows/marko.json
@@ -1,6 +1,7 @@
 {
   "<website-latest-content-list-flow>": {
     "template": "./latest-content-list.marko",
+    "<adunit>": {},
     "@nodes": "array",
     "@with-header": "boolean",
     "@modifiers": "array"

--- a/sites/sdcexec.com/server/components/flows/marko.json
+++ b/sites/sdcexec.com/server/components/flows/marko.json
@@ -3,6 +3,7 @@
     "template": "./latest-content-list.marko",
     "<adunit>": {},
     "@nodes": "array",
+    "@header": "string",
     "@with-header": "boolean",
     "@modifiers": "array"
   },

--- a/sites/sdcexec.com/server/components/marko.json
+++ b/sites/sdcexec.com/server/components/marko.json
@@ -18,5 +18,9 @@
   },
   "<website-inquiry-form>": {
     "template": "./inquiry-form.marko"
+  },
+  "<website-fixed-ad-bottom>": {
+    "template": "./fixed-ad-bottom.marko",
+    "@aliases": "array"
   }
 }

--- a/sites/sdcexec.com/server/routes/content.js
+++ b/sites/sdcexec.com/server/routes/content.js
@@ -1,5 +1,6 @@
 const { withContent } = require('@base-cms/marko-web/middleware');
 const content = require('../templates/content');
+const contact = require('../templates/content/contact');
 const company = require('../templates/content/company');
 const whitepaper = require('../templates/content/whitepaper');
 const queryFragment = require('../graphql/fragments/content-page');
@@ -11,6 +12,10 @@ module.exports = (app) => {
   }));
   app.get('/*?company/:id(\\d{8})*', withContent({
     template: company,
+    queryFragment,
+  }));
+  app.get('/*?contact/:id(\\d{8})*', withContent({
+    template: contact,
     queryFragment,
   }));
   app.get('/*?:id(\\d{8})*', withContent({

--- a/sites/sdcexec.com/server/styles/index.scss
+++ b/sites/sdcexec.com/server/styles/index.scss
@@ -436,6 +436,14 @@ $theme-item-footer-font-size: 12px !default;
     }
   }
 
+  &--infinite-scroll {
+    #{ $self } {
+      &__node:first-child {
+        @include marko-web-node-list-border(border-top);
+      }
+    }
+  }
+
   &--flush-y {
     #{ $self } {
       &__header:first-child {

--- a/sites/sdcexec.com/server/styles/index.scss
+++ b/sites/sdcexec.com/server/styles/index.scss
@@ -331,36 +331,7 @@ $theme-item-footer-font-size: 12px !default;
 }
 
 .page-image {
-  // @todo the $ar calculations can be moved once added to core.
   $self: &;
-  @each $ar in $marko-web-node-image-aspect-ratios {
-    $x: nth($ar, 1);
-    $y: nth($ar, 2);
-
-    &--fluid-#{$x}by#{$y} {
-      #{ $self } {
-        &__wrapper {
-          @include marko-web-node-fluid-image($x, $y);
-        }
-        &__image {
-          @include marko-web-node-fluid-image-item();
-        }
-      }
-    }
-    // Add the inverse ratios (16by9 becomes 9by16, 4by3 becomes 3by4, etc)
-    @if $x != $y {
-      &--fluid-#{$y}by#{$x} {
-        #{ $self } {
-          &__wrapper {
-            @include marko-web-node-fluid-image($x, $y);
-          }
-          &__image {
-            @include marko-web-node-fluid-image-item();
-          }
-        }
-      }
-    }
-  }
 
   &__image-caption,
   &__image-credit {

--- a/sites/sdcexec.com/server/styles/index.scss
+++ b/sites/sdcexec.com/server/styles/index.scss
@@ -488,3 +488,11 @@ $theme-item-footer-font-size: 12px !default;
     }
   }
 }
+
+.magazine-publication-card-block {
+  &__header,
+  &__body {
+    padding-right: 0;
+    padding-left: 0;
+  }
+}

--- a/sites/sdcexec.com/server/templates/content/company.marko
+++ b/sites/sdcexec.com/server/templates/content/company.marko
@@ -132,9 +132,9 @@ $ const { id, type, pageNode } = data;
     </marko-web-resolve-page>
   </@below-page>
   <@foot>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      $ const aliases = hierarchyAliases(content.primarySection);
-      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=0 />
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
     </marko-web-resolve-page>
   </@foot>
 </marko-web-content-page-layout>

--- a/sites/sdcexec.com/server/templates/content/company.marko
+++ b/sites/sdcexec.com/server/templates/content/company.marko
@@ -134,7 +134,7 @@ $ const { id, type, pageNode } = data;
   <@foot>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+      <website-fixed-ad-bottom aliases=hierarchyAliases(section) />
     </marko-web-resolve-page>
   </@foot>
 </marko-web-content-page-layout>

--- a/sites/sdcexec.com/server/templates/content/contact.marko
+++ b/sites/sdcexec.com/server/templates/content/contact.marko
@@ -1,0 +1,91 @@
+import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import { getAsObject, get } from "@base-cms/object-path";
+import queryFragment from "../../graphql/fragments/content-list";
+import GAM from "../../../config/gam";
+
+$ const { site } = out.global;
+$ const { id, type, pageNode } = data;
+
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-rail-infinite": GAM.getAdUnit({ name: "infinite-rail", aliases }),
+});
+
+<marko-web-content-page-layout id=id type=type>
+  <@head>
+    <marko-web-gtm-content-context|{ context }| id=id>
+      <marko-web-gtm-push data=context />
+    </marko-web-gtm-content-context>
+    <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
+    <marko-web-resolve-page|{ data: content }| node=pageNode>
+      $ const aliases = hierarchyAliases(content.primarySection);
+      <marko-web-gam-slots slots=adSlots({ aliases }) />
+    </marko-web-resolve-page>
+  </@head>
+  <@page>
+    <!-- Refresh sticky, right-rail infinite scroll ad -->
+    <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" />
+
+    <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
+      $ const section = resolved.getAsObject("primarySection");
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-page-wrapper>
+        <@section>
+          <div class="row">
+            <div class="col">
+              <marko-web-gam-display-ad id="gpt-ad-lb1" slots=adSlots({ aliases }) />
+            </div>
+          </div>
+        </@section>
+
+        <@section>
+          <div class="row">
+            <div class="col-lg-8 infinite-scroll-target">
+              <marko-web-content-name tag="h1" class="page-wrapper__title" obj=content />
+
+              <default-theme-page-contents|{ blockName }| class="mb-block">
+                <marko-web-page-image width=300 fluid=false obj=content.primaryImage />
+                <default-theme-content-contact-details obj=content />
+                <marko-web-content-body block-name=blockName obj=content />
+              </default-theme-page-contents>
+
+              <marko-web-query|{ nodes }|
+                name="all-author-content"
+                params={ contactId: id, limit: 12, queryFragment }
+              >
+                <website-latest-content-list-flow nodes=nodes header="Recent Articles" with-header=true />
+              </marko-web-query>
+
+              <website-latest-content-load-more-block max-pages=4>
+                <@query
+                  name="all-author-content"
+                  params={ contactId: id, limit: 12, skip: 12 }
+                />
+                <@page for="content" id=id type=type />
+                <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />
+              </website-latest-content-load-more-block>
+            </div>
+
+            <aside class="col-lg-4 page-rail">
+              <marko-web-node-list collapsible=false>
+                <@header modifiers=["padding-y"]>Follow Us</@header>
+              </marko-web-node-list>
+
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail-infinite"
+                modifiers=["sticky-top"]
+                slots=adSlots({ aliases })
+              />
+            </aside>
+          </div>
+        </@section>
+      </marko-web-page-wrapper>
+    </marko-web-resolve-page>
+  </@page>
+  <@foot>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <website-fixed-ad-bottom aliases=hierarchyAliases(section) />
+    </marko-web-resolve-page>
+  </@foot>
+</marko-web-content-page-layout>

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -13,8 +13,8 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
   "gpt-ad-rail-infinite": GAM.getAdUnit({ name: "infinite-rail", aliases }),
 });
-$ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
-$ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
+$ const displayPrimaryImage = ["whitepaper", "media-gallery"].includes(type) ? false : true;
+$ const displayPublishedDate = ["event", "webinar"].includes(type) ? false : true;
 
 <marko-web-content-page-layout id=id type=type>
   <@head>
@@ -62,9 +62,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                     <marko-web-content-published block-name=blockName obj=content />
                   </if>
                 </default-theme-page-dates>
-                <if(content.type !== "contact")>
-                  <default-theme-content-attribution obj=content />
-                </if>
+                <default-theme-content-attribution obj=content />
               </div>
             </div>
           </div>
@@ -92,9 +90,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                     options={ w: 512, h: 288, fit: 'crop' }
                   />
                 </else>
-              </else-if>
-              <else-if(type === "contact")>
-                <marko-web-page-image width=300 fluid=false obj=content.primaryImage />
               </else-if>
               <default-theme-content-contact-details obj=content />
               <marko-web-content-body block-name=blockName obj=content />

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -160,16 +160,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 name="website-scheduled-content"
                 params={ sectionId: section.id, limit: 6, skip: 8, requiresImage: true, queryFragment }
               >
-                <website-content-list-flow
-                  nodes=nodes
-                  inner-justified=false
-                  modifiers=["padding-large"]
-                >
-                  <@header>Latest</@header>
-                  <@node image-position="left" with-attribution=true with-teaser=true>
-                    <@image use-placeholder=false ar="16:9" width=288 />
-                  </@node>
-                </website-content-list-flow>
+                <website-latest-content-list-flow nodes=nodes with-header=true />
               </marko-web-query>
             </div>
             <aside class="col-lg-4 page-rail">

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -11,7 +11,7 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
   "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
   "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
-  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
+  "gpt-ad-rail-infinite": GAM.getAdUnit({ name: "infinite-rail", aliases }),
 });
 $ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
@@ -174,12 +174,13 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 <website-latest-content-list-flow nodes=nodes with-header=true />
               </marko-web-query>
 
-              <website-latest-content-load-more-block>
+              <website-latest-content-load-more-block max-pages=4>
                 <@query
                   name="website-scheduled-content"
                   params={ sectionId: section.id, limit: 10, skip: 14, requiresImage: true }
                 />
                 <@page for="content" id=id />
+                <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />
               </website-latest-content-load-more-block>
             </div>
             <aside class="col-lg-4 page-rail">
@@ -188,7 +189,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </marko-web-node-list>
 
               <marko-web-gam-display-ad
-                id="gpt-ad-rail3"
+                id="gpt-ad-rail-infinite"
                 modifiers=["sticky-top"]
                 slots=adSlots({ aliases })
               />

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -182,7 +182,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                   name="website-scheduled-content"
                   params={ sectionId: section.id, limit: 12, skip: 20, requiresImage: true }
                 />
-                <@page for="content" id=id />
+                <@page for="content" id=id type=type />
                 <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />
               </website-latest-content-load-more-block>
             </div>

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -27,14 +27,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
       <marko-web-gam-slots slots=adSlots({ aliases }) />
     </marko-web-resolve-page>
   </@head>
-  <!-- @todo the reskin is currently pushing the page donw -->
-  <!-- <@above-container>
-    <marko-web-resolve-page|{ data: content }| node=pageNode>
-      $ const aliases = hierarchyAliases(content.primarySection);
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
-    </marko-web-resolve-page>
-  </@above-container> -->
   <@page>
     <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
@@ -197,4 +189,10 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
+  <@foot>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+    </marko-web-resolve-page>
+  </@foot>
 </marko-web-content-page-layout>

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -6,6 +6,13 @@ import GAM from "../../../config/gam";
 $ const { site } = out.global;
 $ const { id, type, pageNode } = data;
 
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
+  "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
+  "gpt-ad-rail3": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
+});
 $ const displayPrimaryImage = ["whitepaper", "media-gallery", "contact"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? false : true;
 
@@ -17,14 +24,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     <marko-web-gam-targeting key-values={ cont_id: id, cont_type: type } />
     <marko-web-resolve-page|{ data: content }| node=pageNode>
       $ const aliases = hierarchyAliases(content.primarySection);
-      $ const adSlots = {
-        "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
-        "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
-        "gpt-ad-rail3": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
-      }
-       <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots({ aliases }) />
     </marko-web-resolve-page>
   </@head>
   <!-- @todo the reskin is currently pushing the page donw -->
@@ -36,7 +36,6 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     </marko-web-resolve-page>
   </@above-container> -->
   <@page>
-
     <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
       $ const aliases = hierarchyAliases(section);
@@ -44,7 +43,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb1" />
+              <marko-web-gam-display-ad id="gpt-ad-lb1" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -117,7 +116,11 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               </if>
             </default-theme-page-contents>
             <aside class="col-lg-4 page-rail">
-              <marko-web-gam-display-ad id="gpt-ad-rail1" modifiers=["left"] />
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail1"
+                modifiers=["left"]
+                slots=adSlots({ aliases })
+              />
 
               <website-related-content-block
                 id=id
@@ -127,7 +130,11 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 query-fragment=queryFragment
               />
 
-              <marko-web-gam-display-ad id="gpt-ad-rail2" modifiers=["sticky-top", "left"] />
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail2"
+                modifiers=["sticky-top", "left"]
+                slots=adSlots({ aliases })
+              />
             </aside>
           </div>
         </@section>
@@ -154,7 +161,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb2" />
+              <marko-web-gam-display-ad id="gpt-ad-lb2" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -183,7 +190,11 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 <@header modifiers=["padding-y"]>Follow Us</@header>
               </marko-web-node-list>
 
-              <marko-web-gam-display-ad id="gpt-ad-rail3" modifiers=["sticky-top"] />
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail3"
+                modifiers=["sticky-top"]
+                slots=adSlots({ aliases })
+              />
             </aside>
           </div>
         </@section>

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -76,25 +76,20 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
         </@section>
         <@section>
           <div class="row">
-            <default-theme-page-contents|{ blockName }| class="col mb-block">
+            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
               <if(content.embedCode)>
                 <marko-web-content-embed-code block-name=blockName obj=content />
               </if>
               <else-if(displayPrimaryImage)>
-                <!-- @todo ensure newest version of marko-web is added -->
                 <marko-web-page-image
                   obj=content.primaryImage
                   modifiers=["fluid-16by9"]
                   options={ w: 512, h: 288, fit: 'crop' }
                 />
               </else-if>
-            </default-theme-page-contents>
-          </div>
-          <div class="row">
-            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
-              <if(type === "contact")>
+              <else-if(type === "contact")>
                 <marko-web-page-image width=300 fluid=false obj=content.primaryImage />
-              </if>
+              </else-if>
               <default-theme-content-contact-details obj=content />
               <marko-web-content-body block-name=blockName obj=content />
               <marko-web-content-sidebars block-name=blockName obj=content />

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -28,6 +28,9 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
     </marko-web-resolve-page>
   </@head>
   <@page>
+    <!-- Refresh sticky, right-rail infinite scroll ad -->
+    <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" />
+
     <marko-web-resolve-page|{ data: content, resolved }| node=pageNode>
       $ const section = resolved.getAsObject("primarySection");
       $ const aliases = hierarchyAliases(section);
@@ -169,7 +172,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
             <div class="col-lg-8 infinite-scroll-target">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
-                params={ sectionId: section.id, limit: 6, skip: 8, requiresImage: true, queryFragment }
+                params={ sectionId: section.id, limit: 12, skip: 8, requiresImage: true, queryFragment }
               >
                 <website-latest-content-list-flow nodes=nodes with-header=true />
               </marko-web-query>
@@ -177,7 +180,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
               <website-latest-content-load-more-block max-pages=4>
                 <@query
                   name="website-scheduled-content"
-                  params={ sectionId: section.id, limit: 10, skip: 14, requiresImage: true }
+                  params={ sectionId: section.id, limit: 12, skip: 20, requiresImage: true }
                 />
                 <@page for="content" id=id />
                 <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -1,5 +1,5 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
-import { getAsObject } from "@base-cms/object-path";
+import { getAsObject, get } from "@base-cms/object-path";
 import queryFragment from "../../graphql/fragments/content-list";
 import GAM from "../../../config/gam";
 
@@ -73,11 +73,22 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
                 <marko-web-content-embed-code block-name=blockName obj=content />
               </if>
               <else-if(displayPrimaryImage)>
-                <marko-web-page-image
-                  obj=content.primaryImage
-                  modifiers=["fluid-16by9"]
-                  options={ w: 512, h: 288, fit: 'crop' }
-                />
+                $ const isLogo = get(content, "primaryImage.isLogo");
+                <if(isLogo)>
+                  <marko-web-page-image
+                    obj=content.primaryImage
+                    modifiers=["primary-image-inline"]
+                    fluid=false
+                    width=250
+                  />
+                </if>
+                <else>
+                  <marko-web-page-image
+                    obj=content.primaryImage
+                    modifiers=["fluid-16by9"]
+                    options={ w: 512, h: 288, fit: 'crop' }
+                  />
+                </else>
               </else-if>
               <else-if(type === "contact")>
                 <marko-web-page-image width=300 fluid=false obj=content.primaryImage />

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -206,7 +206,7 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
   <@foot>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+      <website-fixed-ad-bottom aliases=hierarchyAliases(section) />
     </marko-web-resolve-page>
   </@foot>
 </marko-web-content-page-layout>

--- a/sites/sdcexec.com/server/templates/content/index.marko
+++ b/sites/sdcexec.com/server/templates/content/index.marko
@@ -155,13 +155,21 @@ $ const displayPublishedDate = ["event", "webinar", "contact"].includes(type) ? 
 
         <@section>
           <div class="row">
-            <div class="col-lg-8">
+            <div class="col-lg-8 infinite-scroll-target">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
                 params={ sectionId: section.id, limit: 6, skip: 8, requiresImage: true, queryFragment }
               >
                 <website-latest-content-list-flow nodes=nodes with-header=true />
               </marko-web-query>
+
+              <website-latest-content-load-more-block>
+                <@query
+                  name="website-scheduled-content"
+                  params={ sectionId: section.id, limit: 10, skip: 14, requiresImage: true }
+                />
+                <@page for="content" id=id />
+              </website-latest-content-load-more-block>
             </div>
             <aside class="col-lg-4 page-rail">
               <marko-web-node-list collapsible=false>

--- a/sites/sdcexec.com/server/templates/dynamic-page/index.marko
+++ b/sites/sdcexec.com/server/templates/dynamic-page/index.marko
@@ -39,6 +39,6 @@ $ const { id, alias, pageNode } = data;
     </marko-web-resolve-page>
   </@page>
   <@foot>
-    <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2" }) refresh-interval=0 />
+    <website-fixed-ad-bottom />
   </@foot>
 </marko-web-dynamic-page-layout>

--- a/sites/sdcexec.com/server/templates/index.marko
+++ b/sites/sdcexec.com/server/templates/index.marko
@@ -5,6 +5,14 @@ import GAM from "../../config/gam";
 
 $ const { id, alias, name, pageNode } = data;
 
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb3":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
+  "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
+});
+
 <marko-web-website-section-page-layout id=id alias=alias name=name>
   <@head>
     <marko-web-gtm-website-section-context|{ context }| alias=alias>
@@ -12,14 +20,7 @@ $ const { id, alias, name, pageNode } = data;
     </marko-web-gtm-website-section-context>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      $ const adSlots = {
-        "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-lb3":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
-        "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
-      }
-      <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots({ aliases }) />
     </marko-web-resolve-page>
   </@head>
   <!-- <@above-container>
@@ -31,6 +32,7 @@ $ const { id, alias, name, pageNode } = data;
   </@above-container> -->
   <@page>
     <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
       <marko-web-page-wrapper>
         <@section>
           <div class="row">
@@ -48,7 +50,7 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb1" />
+              <marko-web-gam-display-ad id="gpt-ad-lb1" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -75,7 +77,7 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb2" />
+              <marko-web-gam-display-ad id="gpt-ad-lb2" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -104,7 +106,11 @@ $ const { id, alias, name, pageNode } = data;
                 <@header modifiers=["padding-y"]>Follow Us</@header>
               </marko-web-node-list>
 
-              <marko-web-gam-display-ad id="gpt-ad-rail1" modifiers=["sticky-top"] />
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail1"
+                modifiers=["sticky-top"]
+                slots=adSlots({ aliases })
+              />
             </aside>
           </div>
         </@section>
@@ -130,7 +136,7 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb3" />
+              <marko-web-gam-display-ad id="gpt-ad-lb3" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -171,7 +177,11 @@ $ const { id, alias, name, pageNode } = data;
                 </website-content-list-flow>
               </marko-web-query>
 
-              <marko-web-gam-display-ad id="gpt-ad-rail2" modifiers=["sticky-top"] />
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail2"
+                modifiers=["sticky-top"]
+                slots=adSlots({ aliases })
+              />
             </aside>
           </div>
         </@section>

--- a/sites/sdcexec.com/server/templates/index.marko
+++ b/sites/sdcexec.com/server/templates/index.marko
@@ -125,12 +125,12 @@ $ const adSlots = ({ aliases }) => ({
           </div>
         </@section>
 
-        <@section modifiers=["infinite-scroll"]>
+        <@section>
           <div class="row">
-            <div class="col-lg-8">
+            <div class="col-lg-8 infinite-scroll-target">
               <marko-web-query|{ nodes }|
                 name="all-published-content"
-                params={ sectionId: id, excludeContentTypes: ["Company", "Contact"], limit: 10, skip: 6, requiresImage: true, queryFragment }
+                params={ excludeContentTypes: ["Company", "Contact"], limit: 10, skip: 6, requiresImage: true, queryFragment }
               >
                 <website-content-list-flow
                   nodes=nodes
@@ -142,6 +142,14 @@ $ const adSlots = ({ aliases }) => ({
                   </@node>
                 </website-content-list-flow>
               </marko-web-query>
+
+              <website-latest-content-load-more-block max-pages=1>
+                <@query
+                  name="all-published-content"
+                  params={ excludeContentTypes: ["Company", "Contact"], limit: 10, skip: 16, requiresImage: true }
+                />
+                <@page for="website-section" id=id />
+              </website-latest-content-load-more-block>
             </div>
 
             <aside class="col-lg-4 page-rail">

--- a/sites/sdcexec.com/server/templates/index.marko
+++ b/sites/sdcexec.com/server/templates/index.marko
@@ -82,16 +82,7 @@ $ const adSlots = ({ aliases }) => ({
                 name="all-published-content"
                 params={ excludeContentTypes: ["Company", "Contact"], limit: 6, requiresImage: true, queryFragment }
               >
-                <website-content-list-flow
-                  nodes=nodes
-                  inner-justified=false
-                  modifiers=["padding-large"]
-                >
-                  <@header>Latest</@header>
-                  <@node image-position="left" with-attribution=true with-teaser=true>
-                    <@image use-placeholder=false ar="16:9" width=288 />
-                  </@node>
-                </website-content-list-flow>
+                <website-latest-content-list-flow nodes=nodes with-header=true />
               </marko-web-query>
             </div>
             <aside class="col-lg-4 page-rail">

--- a/sites/sdcexec.com/server/templates/index.marko
+++ b/sites/sdcexec.com/server/templates/index.marko
@@ -10,7 +10,7 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
   "gpt-ad-lb3":   GAM.getAdUnit({ name: "lb1", aliases }),
   "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
-  "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
+  "gpt-ad-rail-infinite": GAM.getAdUnit({ name: "infinite-rail", aliases }),
 });
 
 <marko-web-website-section-page-layout id=id alias=alias name=name>
@@ -149,6 +149,7 @@ $ const adSlots = ({ aliases }) => ({
                   params={ excludeContentTypes: ["Company", "Contact"], limit: 10, skip: 16, requiresImage: true }
                 />
                 <@page for="website-section" id=id />
+                <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />
               </website-latest-content-load-more-block>
             </div>
 
@@ -170,7 +171,7 @@ $ const adSlots = ({ aliases }) => ({
               </marko-web-query>
 
               <marko-web-gam-display-ad
-                id="gpt-ad-rail2"
+                id="gpt-ad-rail-infinite"
                 modifiers=["sticky-top"]
                 slots=adSlots({ aliases })
               />

--- a/sites/sdcexec.com/server/templates/index.marko
+++ b/sites/sdcexec.com/server/templates/index.marko
@@ -23,13 +23,6 @@ $ const adSlots = ({ aliases }) => ({
       <marko-web-gam-slots slots=adSlots({ aliases }) />
     </marko-web-resolve-page>
   </@head>
-  <!-- <@above-container>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
-    </marko-web-resolve-page>
-  </@above-container> -->
   <@page>
     <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
@@ -188,4 +181,10 @@ $ const adSlots = ({ aliases }) => ({
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
+  <@foot>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+    </marko-web-resolve-page>
+  </@foot>
 </marko-web-website-section-page-layout>

--- a/sites/sdcexec.com/server/templates/index.marko
+++ b/sites/sdcexec.com/server/templates/index.marko
@@ -187,7 +187,7 @@ $ const adSlots = ({ aliases }) => ({
   <@foot>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+      <website-fixed-ad-bottom aliases=hierarchyAliases(section) />
     </marko-web-resolve-page>
   </@foot>
 </marko-web-website-section-page-layout>

--- a/sites/sdcexec.com/server/templates/index.marko
+++ b/sites/sdcexec.com/server/templates/index.marko
@@ -24,6 +24,9 @@ $ const adSlots = ({ aliases }) => ({
     </marko-web-resolve-page>
   </@head>
   <@page>
+    <!-- Refresh sticky, right-rail infinite scroll ad -->
+    <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" />
+
     <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
       <marko-web-page-wrapper>
@@ -130,7 +133,7 @@ $ const adSlots = ({ aliases }) => ({
             <div class="col-lg-8 infinite-scroll-target">
               <marko-web-query|{ nodes }|
                 name="all-published-content"
-                params={ excludeContentTypes: ["Company", "Contact"], limit: 10, skip: 6, requiresImage: true, queryFragment }
+                params={ excludeContentTypes: ["Company", "Contact"], limit: 12, skip: 6, requiresImage: true, queryFragment }
               >
                 <website-content-list-flow
                   nodes=nodes
@@ -146,7 +149,7 @@ $ const adSlots = ({ aliases }) => ({
               <website-latest-content-load-more-block max-pages=1>
                 <@query
                   name="all-published-content"
-                  params={ excludeContentTypes: ["Company", "Contact"], limit: 10, skip: 16, requiresImage: true }
+                  params={ excludeContentTypes: ["Company", "Contact"], limit: 12, skip: 18, requiresImage: true }
                 />
                 <@page for="website-section" id=id />
                 <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />

--- a/sites/sdcexec.com/server/templates/magazine/index.marko
+++ b/sites/sdcexec.com/server/templates/magazine/index.marko
@@ -12,19 +12,16 @@ $ const description = site.get("magazines.description");
       <marko-web-gtm-push data=context />
     </marko-web-gtm-default-context>
   </@head>
-  <@above-container>
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa" }) />
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
-  </@above-container>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
-    <marko-web-page-wrapper class="mb-block">
+    <marko-web-page-wrapper>
+      <@section>
+        <marko-web-gam-define-display-ad
+          ...GAM.getAdUnit({ name: "lb1" })
+        />
+      </@section>
       <@section>
         <div class="row">
           <div class="col">
-            <default-theme-breadcrumbs-with-home>
-              <@item>${title}</@item>
-            </default-theme-breadcrumbs-with-home>
             <h1 class="page-wrapper__title">${title}</h1>
             <if(description)>
               <p class="page-wrapper__deck">${description}</p>

--- a/sites/sdcexec.com/server/templates/magazine/issue.marko
+++ b/sites/sdcexec.com/server/templates/magazine/issue.marko
@@ -10,13 +10,13 @@ $ const { id, pageNode } = data;
       <marko-web-gtm-push data=context />
     </marko-web-gtm-magazine-issue-context>
   </@head>
-  <@above-container>
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa" }) />
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
-  </@above-container>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
+      <@section>
+        <marko-web-gam-define-display-ad
+          ...GAM.getAdUnit({ name: "lb1" })
+        />
+      </@section>
       <@section>
         <div class="row">
           <div class="col">

--- a/sites/sdcexec.com/server/templates/magazine/publication.marko
+++ b/sites/sdcexec.com/server/templates/magazine/publication.marko
@@ -8,13 +8,13 @@ $ const { id, pageNode } = data;
       <marko-web-gtm-push data=context />
     </marko-web-gtm-magazine-publication-context>
   </@head>
-  <@above-container>
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa" }) />
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
-  </@above-container>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
-    <marko-web-page-wrapper>
+    <marko-web-page-wrapper class="mb-block">
+      <@section>
+        <marko-web-gam-define-display-ad
+          ...GAM.getAdUnit({ name: "lb1" })
+        />
+      </@section>
       <@section>
         <div class="row">
           <div class="col">

--- a/sites/sdcexec.com/server/templates/published-content/events.marko
+++ b/sites/sdcexec.com/server/templates/published-content/events.marko
@@ -52,6 +52,6 @@ $ const now = (new Date()).valueOf();
     />
   </@below-page>
   <@foot>
-    <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2" }) refresh-interval=0 />
+    <website-fixed-ad-bottom />
   </@foot>
 </marko-web-default-page-layout>

--- a/sites/sdcexec.com/server/templates/published-content/videos.marko
+++ b/sites/sdcexec.com/server/templates/published-content/videos.marko
@@ -51,6 +51,6 @@ $ const description = defaultDescription(title, config);
     />
   </@below-page>
   <@foot>
-    <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2" }) refresh-interval=0 />
+    <website-fixed-ad-bottom />
   </@foot>
 </marko-web-default-page-layout>

--- a/sites/sdcexec.com/server/templates/published-content/webinars.marko
+++ b/sites/sdcexec.com/server/templates/published-content/webinars.marko
@@ -51,6 +51,6 @@ $ const description = defaultDescription(title, config);
     />
   </@below-page>
   <@foot>
-    <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2" }) refresh-interval=0 />
+    <website-fixed-ad-bottom />
   </@foot>
 </marko-web-default-page-layout>

--- a/sites/sdcexec.com/server/templates/published-content/white-papers.marko
+++ b/sites/sdcexec.com/server/templates/published-content/white-papers.marko
@@ -51,6 +51,6 @@ $ const description = defaultDescription(title, config);
     />
   </@below-page>
   <@foot>
-    <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2" }) refresh-interval=0 />
+    <website-fixed-ad-bottom />
   </@foot>
 </marko-web-default-page-layout>

--- a/sites/sdcexec.com/server/templates/search.marko
+++ b/sites/sdcexec.com/server/templates/search.marko
@@ -14,8 +14,12 @@ $ const description = `Search ${config.siteName()}`;
     </marko-web-gtm-default-context>
   </@head>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
     <marko-web-page-wrapper class="mb-block">
+      <@section>
+        <marko-web-gam-define-display-ad
+          ...GAM.getAdUnit({ name: "lb1" })
+        />
+      </@section>
       <@section>
         <div class="row">
           <div class="col">

--- a/sites/sdcexec.com/server/templates/website-section/contact-us.marko
+++ b/sites/sdcexec.com/server/templates/website-section/contact-us.marko
@@ -12,26 +12,25 @@ $ const { id, alias, name, pageNode } = data;
     <!-- @todo this should be removed once contact us is in core -->
     <script src="https://www.google.com/recaptcha/api.js?onload=vueRecaptchaApiLoaded&render=explicit" async defer></script>
   </@head>
-  <@above-container>
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa" }) />
-    <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin" }) />
-  </@above-container>
   <@page>
-    <marko-web-gam-define-display-ad ...GAM.getAdUnit({ name: "lb1" }) modifiers=["top-of-page"] />
-
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       <marko-web-page-wrapper>
         <@section>
+          <marko-web-gam-define-display-ad
+            ...GAM.getAdUnit({ name: "lb1" })
+          />
+        </@section>
+        <@section>
           <div class="row">
             <div class="col">
-              <default-theme-website-section-breadcrumbs section=section />
+              <default-theme-website-section-breadcrumbs section=section display-self=false />
               <marko-web-website-section-name tag="h1" class="page-wrapper__title" obj=section />
             </div>
           </div>
         </@section>
         <@section>
           <div class="row">
-            <default-theme-page-contents|{ blockName }| class="col-lg-8">
+            <default-theme-page-contents|{ blockName }| class="col-lg-8 mb-3 mb-lg-0">
               <marko-web-query|{ nodes }| name="website-scheduled-content" params={ sectionId: id, limit: 100, queryFragment }>
                 <for|node| of=nodes>
                   <website-contact-us-list-node node=node />

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -86,16 +86,7 @@ $ const adSlots = ({ aliases }) => ({
                 name="website-scheduled-content"
                 params={ sectionId: id, limit: 6, skip: 9, requiresImage: true, queryFragment }
               >
-                <website-content-list-flow
-                  nodes=nodes
-                  inner-justified=false
-                  modifiers=["padding-large"]
-                >
-                  <@header>Latest</@header>
-                  <@node image-position="left" with-attribution=true with-teaser=true>
-                    <@image use-placeholder=false ar="16:9" width=288 />
-                  </@node>
-                </website-content-list-flow>
+                <website-latest-content-list-flow nodes=nodes with-header=true />
               </marko-web-query>
             </div>
             <aside class="col-lg-4 page-rail">

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -131,21 +131,24 @@ $ const adSlots = ({ aliases }) => ({
 
         <@section modifiers=["infinite-scroll"]>
           <div class="row">
-            <div class="col-lg-8">
+            <div class="col-lg-8 infinite-scroll-target">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
                 params={ sectionId: id, limit: 10, skip: 15, requiresImage: true, queryFragment }
               >
-                <website-content-list-flow
-                  nodes=nodes
-                  inner-justified=false
-                  modifiers=["padding-large"]
-                >
-                  <@node image-position="left" with-attribution=true with-teaser=true>
-                    <@image use-placeholder=false ar="16:9" width=288 />
-                  </@node>
-                </website-content-list-flow>
+                <website-latest-content-list-flow nodes=nodes with-header=false />
               </marko-web-query>
+
+              <marko-web-load-more
+                append-to=".infinite-scroll-target"
+                expand=500
+                component-name="latest-content-list-flow"
+                component-input={ withHeader: false, modifiers: ["infinite-scroll"] }
+                fragment-name="content-list"
+                query-name="website-scheduled-content"
+                query-params={ sectionId: id, limit: 10, skip: 25, requiresImage: true }
+                page-input={ for: "website-section", id }
+              />
             </div>
 
             <aside class="col-lg-4 page-rail">

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -9,7 +9,7 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
   "gpt-ad-lb3":   GAM.getAdUnit({ name: "lb1", aliases }),
   "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
-  "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
+  "gpt-ad-rail-infinite": GAM.getAdUnit({ name: "infinite-rail", aliases }),
 });
 
 <marko-web-website-section-page-layout id=id alias=alias name=name>
@@ -139,12 +139,13 @@ $ const adSlots = ({ aliases }) => ({
                 <website-latest-content-list-flow nodes=nodes with-header=false />
               </marko-web-query>
 
-              <website-latest-content-load-more-block>
+              <website-latest-content-load-more-block max-pages=4>
                 <@query
                   name="website-scheduled-content"
                   params={ sectionId: id, limit: 10, skip: 25, requiresImage: true }
                 />
                 <@page for="website-section" id=id />
+                <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />
               </website-latest-content-load-more-block>
             </div>
 
@@ -166,7 +167,7 @@ $ const adSlots = ({ aliases }) => ({
               </marko-web-query>
 
               <marko-web-gam-display-ad
-                id="gpt-ad-rail2"
+                id="gpt-ad-rail-infinite"
                 modifiers=["sticky-top"]
                 slots=adSlots({ aliases })
               />

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -139,16 +139,13 @@ $ const adSlots = ({ aliases }) => ({
                 <website-latest-content-list-flow nodes=nodes with-header=false />
               </marko-web-query>
 
-              <marko-web-load-more
-                append-to=".infinite-scroll-target"
-                expand=500
-                component-name="latest-content-list-flow"
-                component-input={ withHeader: false, modifiers: ["infinite-scroll"] }
-                fragment-name="content-list"
-                query-name="website-scheduled-content"
-                query-params={ sectionId: id, limit: 10, skip: 25, requiresImage: true }
-                page-input={ for: "website-section", id }
-              />
+              <website-latest-content-load-more-block>
+                <@query
+                  name="website-scheduled-content"
+                  params={ sectionId: id, limit: 10, skip: 25, requiresImage: true }
+                />
+                <@page for="website-section" id=id />
+              </website-latest-content-load-more-block>
             </div>
 
             <aside class="col-lg-4 page-rail">

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -23,6 +23,9 @@ $ const adSlots = ({ aliases }) => ({
     </marko-web-resolve-page>
   </@head>
   <@page>
+    <!-- Refresh sticky, right-rail infinite scroll ad -->
+    <marko-web-gam-refresh-ad on="load-more-in-view" slot-id="gpt-ad-rail-infinite" />
+
     <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
       <marko-web-page-wrapper>
@@ -134,7 +137,7 @@ $ const adSlots = ({ aliases }) => ({
             <div class="col-lg-8 infinite-scroll-target">
               <marko-web-query|{ nodes }|
                 name="website-scheduled-content"
-                params={ sectionId: id, limit: 10, skip: 15, requiresImage: true, queryFragment }
+                params={ sectionId: id, limit: 12, skip: 15, requiresImage: true, queryFragment }
               >
                 <website-latest-content-list-flow nodes=nodes with-header=false />
               </marko-web-query>
@@ -142,7 +145,7 @@ $ const adSlots = ({ aliases }) => ({
               <website-latest-content-load-more-block max-pages=4>
                 <@query
                   name="website-scheduled-content"
-                  params={ sectionId: id, limit: 10, skip: 25, requiresImage: true }
+                  params={ sectionId: id, limit: 12, skip: 27, requiresImage: true }
                 />
                 <@page for="website-section" id=id />
                 <@adunit ...GAM.getAdUnit({ name: "infinite-interstitial", aliases }) />

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -183,7 +183,7 @@ $ const adSlots = ({ aliases }) => ({
   <@foot>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+      <website-fixed-ad-bottom aliases=hierarchyAliases(section) />
     </marko-web-resolve-page>
   </@foot>
 </marko-web-website-section-page-layout>

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -4,6 +4,14 @@ import GAM from "../../../config/gam";
 
 $ const { id, alias, name, pageNode } = data;
 
+$ const adSlots = ({ aliases }) => ({
+  "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-lb3":   GAM.getAdUnit({ name: "lb1", aliases }),
+  "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
+  "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
+});
+
 <marko-web-website-section-page-layout id=id alias=alias name=name>
   <@head>
     <marko-web-gtm-website-section-context|{ context }| alias=alias>
@@ -11,14 +19,7 @@ $ const { id, alias, name, pageNode } = data;
     </marko-web-gtm-website-section-context>
     <marko-web-resolve-page|{ data: section }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
-      $ const adSlots = {
-        "gpt-ad-lb1":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-lb2":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-lb3":   GAM.getAdUnit({ name: "lb1", aliases }),
-        "gpt-ad-rail1": GAM.getAdUnit({ name: "rail1", aliases, size: [300, 250] }),
-        "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases, size: [300, 600] }),
-      }
-      <marko-web-gam-slots slots=adSlots />
+      <marko-web-gam-slots slots=adSlots({ aliases }) />
     </marko-web-resolve-page>
   </@head>
   <!-- <@above-container>
@@ -30,6 +31,7 @@ $ const { id, alias, name, pageNode } = data;
   </@above-container> -->
   <@page>
     <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
       <marko-web-page-wrapper>
         <@section>
           <marko-web-node-list collapsible=false>
@@ -52,7 +54,7 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb1" />
+              <marko-web-gam-display-ad id="gpt-ad-lb1" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -79,7 +81,7 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb2" />
+              <marko-web-gam-display-ad id="gpt-ad-lb2" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -108,7 +110,11 @@ $ const { id, alias, name, pageNode } = data;
                 <@header modifiers=["padding-y"]>Follow Us</@header>
               </marko-web-node-list>
 
-              <marko-web-gam-display-ad id="gpt-ad-rail1" modifiers=["sticky-top"] />
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail1"
+                modifiers=["sticky-top"]
+                slots=adSlots({ aliases })
+              />
             </aside>
           </div>
         </@section>
@@ -134,7 +140,7 @@ $ const { id, alias, name, pageNode } = data;
         <@section>
           <div class="row">
             <div class="col">
-              <marko-web-gam-display-ad id="gpt-ad-lb3" />
+              <marko-web-gam-display-ad id="gpt-ad-lb3" slots=adSlots({ aliases }) />
             </div>
           </div>
         </@section>
@@ -175,7 +181,11 @@ $ const { id, alias, name, pageNode } = data;
                 </website-content-list-flow>
               </marko-web-query>
 
-              <marko-web-gam-display-ad id="gpt-ad-rail2" modifiers=["sticky-top"] />
+              <marko-web-gam-display-ad
+                id="gpt-ad-rail2"
+                modifiers=["sticky-top"]
+                slots=adSlots({ aliases })
+              />
             </aside>
           </div>
         </@section>

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -22,13 +22,6 @@ $ const adSlots = ({ aliases }) => ({
       <marko-web-gam-slots slots=adSlots({ aliases }) />
     </marko-web-resolve-page>
   </@head>
-  <!-- <@above-container>
-    <marko-web-resolve-page|{ data: section }| node=pageNode>
-      $ const aliases = hierarchyAliases(section);
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "wa", aliases }) />
-      <marko-web-gam-out-of-page-ad ...GAM.getAdUnit({ name: "reskin", aliases }) />
-    </marko-web-resolve-page>
-  </@above-container> -->
   <@page>
     <marko-web-resolve-page|{ data: section, resolved }| node=pageNode>
       $ const aliases = hierarchyAliases(section);
@@ -192,4 +185,10 @@ $ const adSlots = ({ aliases }) => ({
       </marko-web-page-wrapper>
     </marko-web-resolve-page>
   </@page>
+  <@foot>
+    <marko-web-resolve-page|{ data: section }| node=pageNode>
+      $ const aliases = hierarchyAliases(section);
+      <marko-web-gam-fixed-ad-bottom ...GAM.getAdUnit({ name: "lb2", aliases }) refresh-interval=15 scroll-offset=100 />
+    </marko-web-resolve-page>
+  </@foot>
 </marko-web-website-section-page-layout>

--- a/sites/sdcexec.com/server/templates/website-section/index.marko
+++ b/sites/sdcexec.com/server/templates/website-section/index.marko
@@ -129,7 +129,7 @@ $ const adSlots = ({ aliases }) => ({
           </div>
         </@section>
 
-        <@section modifiers=["infinite-scroll"]>
+        <@section>
           <div class="row">
             <div class="col-lg-8 infinite-scroll-target">
               <marko-web-query|{ nodes }|


### PR DESCRIPTION
- Fix search page layout
- Move content primary image to content body column (prevents image from being full width)
- Create content list flow and load more block
- Add bottom sticky leaderboard on mobile only (`< 576px`)
- Apply load more to home, section, and content pages
- Only display infinite scroll right-rail ad on desktop. On mobile,  display the ad interstitially between load more pages
- Clean response bodies and remove Marko template artifacts (reduces page size by ~50%)
- Refresh infinite-scroll sticky right-rail ad on load more
- Cleanup contact us page to match layout
- Create custom contact page layout
- Cleanup magazine pages (root, issue archive, issue content) to match layout