### PR TITLE
Mix equipment updates

### DIFF
--- a/sites/mixequipmentmag.com/browser/index.js
+++ b/sites/mixequipmentmag.com/browser/index.js
@@ -2,7 +2,9 @@ import Browser from '@base-cms/marko-web/browser';
 import DefaultTheme from '@base-cms/marko-web-theme-default/browser';
 import GTM from '@base-cms/marko-web-gtm/browser';
 import Common from '@ac-business-media/package-common/browser';
+import SocialSharing from '@base-cms/marko-web-social-sharing/browser';
 
+SocialSharing(Browser);
 DefaultTheme(Browser);
 GTM(Browser);
 Common(Browser);

--- a/sites/mixequipmentmag.com/config/navigation.js
+++ b/sites/mixequipmentmag.com/config/navigation.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: '/magazine', label: 'Magazine' },
+      { href: '/magazine/5dea77962231ca27128b45f9', label: 'Magazine' },
     ],
   },
   tertiary: {
@@ -39,7 +39,7 @@ module.exports = {
     {
       label: 'Archives',
       items: [
-        { href: '/magazine', label: 'Magazine' },
+        { href: '/magazine/5dea77962231ca27128b45f9', label: 'Magazine' },
       ],
     },
     {

--- a/sites/mixequipmentmag.com/config/navigation.js
+++ b/sites/mixequipmentmag.com/config/navigation.js
@@ -37,7 +37,7 @@ module.exports = {
       ],
     },
     {
-      label: 'Resources',
+      label: 'Archives',
       items: [
         { href: '/magazine', label: 'Magazine' },
       ],

--- a/sites/mixequipmentmag.com/package.json
+++ b/sites/mixequipmentmag.com/package.json
@@ -20,6 +20,7 @@
     "@base-cms/marko-web": "^1.6.3",
     "@base-cms/marko-web-gtm": "^1.0.3",
     "@base-cms/marko-web-icons": "^1.0.0",
+    "@base-cms/marko-web-social-sharing": "^1.5.1",
     "@base-cms/marko-web-theme-default": "^1.6.7",
     "@base-cms/object-path": "^1.0.0",
     "@base-cms/utils": "^1.0.0",

--- a/sites/mixequipmentmag.com/server/components/document.marko
+++ b/sites/mixequipmentmag.com/server/components/document.marko
@@ -18,6 +18,6 @@ $ const { site, req } = out.global;
   </@above-container>
   <@below-container>
     <${input.belowContainer} />
-    <default-theme-site-footer />
+    <website-site-footer />
   </@below-container>
 </marko-web-document>

--- a/sites/mixequipmentmag.com/server/components/marko.json
+++ b/sites/mixequipmentmag.com/server/components/marko.json
@@ -15,5 +15,8 @@
     },
     "<below-container>": {},
     "<foot>": {}
+  },
+  "<website-site-footer>": {
+    "template": "./site-footer.marko"
   }
 }

--- a/sites/mixequipmentmag.com/server/components/nodes/content-card.marko
+++ b/sites/mixequipmentmag.com/server/components/nodes/content-card.marko
@@ -1,8 +1,11 @@
 import { getAsObject } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
+
+$ const withDates = defaultValue(input.withDates, false);
 
 <marko-web-node
   type=`${content.type}-content`
@@ -37,9 +40,11 @@ $ const primarySection = getAsObject(content, "primarySection");
       <@left>
         <attribution content=content />
       </@left>
-      <@right|{ blockName }|>
-        <dates block-name=blockName content=content />
-      </@right>
+      <if(withDates)>
+        <@right|{ blockName }|>
+          <dates block-name=blockName content=content />
+        </@right>
+      </if>
     </@footer>
   </@body>
 </marko-web-node>

--- a/sites/mixequipmentmag.com/server/components/nodes/content-hero-card.marko
+++ b/sites/mixequipmentmag.com/server/components/nodes/content-hero-card.marko
@@ -1,8 +1,11 @@
 import { getAsObject } from "@base-cms/object-path";
+import defaultValue from "@base-cms/marko-core/utils/default-value";
 
 $ const content = getAsObject(input, "node");
 $ const primaryImage = getAsObject(content, "primaryImage");
 $ const primarySection = getAsObject(content, "primarySection");
+
+$ const withDates = defaultValue(input.withDates, false);
 
 <marko-web-node
   type=`${content.type}-content`
@@ -35,6 +38,11 @@ $ const primarySection = getAsObject(content, "primarySection");
       <@left>
         <marko-web-website-section-name obj=primarySection link=true />
       </@left>
+      <if(withDates)>
+        <@right|{ blockName }|>
+          <dates block-name=blockName content=content />
+        </@right>
+      </if>
     </@header>
   </@body>
 </marko-web-node>

--- a/sites/mixequipmentmag.com/server/components/nodes/content-list.marko
+++ b/sites/mixequipmentmag.com/server/components/nodes/content-list.marko
@@ -11,7 +11,7 @@ $ const imagePosition = defaultValue(input.imagePosition, "right");
 $ const withTeaser = defaultValue(input.withTeaser, false);
 $ const withSection = defaultValue(input.withSection, false);
 $ const withAttribution = defaultValue(input.withAttribution, false);
-$ const withDates = defaultValue(input.withDates, true);
+$ const withDates = defaultValue(input.withDates, false);
 
 $ const { linkAttrs } = input;
 

--- a/sites/mixequipmentmag.com/server/components/nodes/marko.json
+++ b/sites/mixequipmentmag.com/server/components/nodes/marko.json
@@ -1,11 +1,13 @@
 {
   "<website-content-card-node>": {
     "template": "./content-card.marko",
-    "@node": "object"
+    "@node": "object",
+    "@with-dates": "boolean"
   },
   "<website-content-hero-card-node>": {
     "template": "./content-hero-card.marko",
-    "@node": "object"
+    "@node": "object",
+    "@with-dates": "boolean"
   },
   "<website-content-list-node>": {
     "template": "./content-list.marko",

--- a/sites/mixequipmentmag.com/server/components/site-footer.marko
+++ b/sites/mixequipmentmag.com/server/components/site-footer.marko
@@ -1,0 +1,41 @@
+$ const { config, site } = out.global;
+
+$ const blockName = input.blockName || "site-footer";
+
+<marko-web-block
+  name=blockName
+  tag=(input.tag || "footer")
+  class=input.class
+  modifiers=input.modifiers
+  attrs=input.attrs
+>
+  <default-theme-site-footer-container block-name=blockName modifiers=["secondary"]>
+    <default-theme-site-navbar-brand block-name=blockName title=`${config.website("name")} Homepage`>
+      <default-theme-site-navbar-logo
+        block-name=blockName
+        alt=config.website("name")
+        src=site.get("logos.footer.src")
+        srcset=site.getAsArray("logos.footer.srcset").join(",")
+        lazyload=true
+      />
+    </default-theme-site-navbar-brand>
+  </default-theme-site-footer-container>
+  <default-theme-site-footer-container block-name=blockName modifiers=["primary"]>
+    <default-theme-site-footer-social-icons
+      block-name=blockName
+      items=site.getAsArray('socialMediaLinks')
+      icon-modifiers=["light", "xl", "shadow"]
+    />
+    <default-theme-site-navbar-items
+      block-name=blockName
+      items=site.getAsArray("navigation.footer.items")
+      reg-enabled=input.regEnabled
+      has-user=input.hasUser
+    />
+    <p class=`${blockName}__contact-info`>For more information contact the Astec sales department at <a href="tel:423-867-4210">423-867-4210</a> or email Pam Harris <a href="mailto:pharris@astecinc.com">pharris@astecinc.com</a></p>
+    <default-theme-site-footer-copyright
+      company=site.get("company")
+      notice=site.get("copyrightNotice")
+    />
+  </default-theme-site-footer-container>
+</marko-web-block>

--- a/sites/mixequipmentmag.com/server/graphql/fragments/content-page.js
+++ b/sites/mixequipmentmag.com/server/graphql/fragments/content-page.js
@@ -7,6 +7,9 @@ fragment ContentPageFragment on Content {
   teaser(input: { useFallback: false, maxLength: null })
   body
   published
+  siteContext {
+    path
+  }
   company {
     id
     name

--- a/sites/mixequipmentmag.com/server/routes/magazine.js
+++ b/sites/mixequipmentmag.com/server/routes/magazine.js
@@ -1,5 +1,4 @@
 const { withMagazineIssue, withMagazinePublication } = require('@base-cms/marko-web/middleware');
-const index = require('../templates/magazine');
 const publication = require('../templates/magazine/publication');
 const publicationFragment = require('../graphql/fragments/magazine-publication-page');
 const issue = require('../templates/magazine/issue');
@@ -7,7 +6,8 @@ const issueFragment = require('../graphql/fragments/magazine-issue-page');
 
 module.exports = (app) => {
   app.get('/magazine', (req, res) => {
-    res.marko(index);
+    // Force redirect to publication archive page.
+    res.redirect(301, '/magazine/5dea77962231ca27128b45f9');
   });
 
   app.get('/magazine/:id([a-fA-F0-9]{24})', withMagazinePublication({

--- a/sites/mixequipmentmag.com/server/styles/index.scss
+++ b/sites/mixequipmentmag.com/server/styles/index.scss
@@ -593,3 +593,20 @@ body {
     padding-left: 0;
   }
 }
+
+.site-footer {
+  &__contact-info {
+    max-width: 400px;
+    margin-right: auto;
+    margin-left: auto;
+    color: $tan-secondary;
+
+    a {
+      color: $tan-light;
+      text-decoration: underline;
+      &:hover {
+        color: $tan-lighter;
+      }
+    }
+  }
+}

--- a/sites/mixequipmentmag.com/server/styles/index.scss
+++ b/sites/mixequipmentmag.com/server/styles/index.scss
@@ -393,6 +393,14 @@ body {
     ul {
       padding-left: $grid-gutter-width;
     }
+
+    blockquote {
+      padding: 10.5px 21px;
+      margin: 0 0 21px;
+      font-size: 18.75px;
+      color: #6f6f6f;
+      border-left: 5px solid #ddd;
+    }
   }
 }
 
@@ -609,5 +617,34 @@ body {
         color: $tan-lighter;
       }
     }
+  }
+}
+
+
+
+.pullquote {
+  position: relative;
+
+  float: right;
+  width: 50%;
+  max-width: 50%;
+  padding: 12px 0 12px 12px;
+  margin: 6px 0 6px 12px;
+
+  font-size: 18.75px;
+
+  color: #6f6f6f;
+
+  &::before {
+    position: absolute;
+    left: 0;
+    z-index: -1;
+
+    font-size: 8em;
+    line-height: .6em;
+
+    color: rgb(204, 204, 204);
+
+    content: "“";
   }
 }

--- a/sites/mixequipmentmag.com/server/styles/index.scss
+++ b/sites/mixequipmentmag.com/server/styles/index.scss
@@ -219,6 +219,7 @@ $theme-item-footer-color: $tan-dark !default;
 $theme-item-footer-font-size: 12px !default;
 
 @import "../../node_modules/@base-cms/marko-web-theme-default/scss/theme";
+@import "../../node_modules/@base-cms/marko-web-social-sharing/scss/buttons";
 // @todo this should be remove once contact us is in core
 @import "../../node_modules/@ac-business-media/package-common/scss/contact-us-form";
 

--- a/sites/mixequipmentmag.com/server/templates/content/index.marko
+++ b/sites/mixequipmentmag.com/server/templates/content/index.marko
@@ -67,7 +67,11 @@ $ const displayPublishedDate = ["event", "webinar"].includes(type) ? false : tru
         <@section modifiers=["content-page"]>
           <div class="row">
             <default-theme-page-contents|{ blockName }| class="col">
-              <marko-web-content-body block-name=blockName obj=content />
+              <marko-web-social-sharing
+                path=content.siteContext.path
+                providers=["email", "facebook", "linkedin", "twitter"]
+              />
+              <marko-web-content-body block-name=blockName obj=content class="mt-block" />
               <marko-web-content-sidebars block-name=blockName obj=content />
               <if(type === "document")>
                 <default-theme-content-download obj=content>

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,6 +849,13 @@
     "@base-cms/utils" "^1.0.0"
     node-fetch "^2.6.0"
 
+"@base-cms/marko-web-social-sharing@^1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@base-cms/marko-web-social-sharing/-/marko-web-social-sharing-1.5.1.tgz#2980405c1c98d3bcd7a2c3c8224e0e4a069dfb2a"
+  integrity sha512-n51wtOMvEp0WxLqHxciCl46inDgaQ88KDx9UcDW8Dx8PCZ2v1Kz/KYlBYGjSeg3oKkx/x+8Q+FJ2Gnse8Uz/vw==
+  dependencies:
+    "@base-cms/utils" "^1.0.0"
+
 "@base-cms/marko-web-theme-default@^1.6.7":
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/@base-cms/marko-web-theme-default/-/marko-web-theme-default-1.6.7.tgz#5b1aba03d7bccb6a6f2601d6421124034a7cdbce"


### PR DESCRIPTION
- disable dates from content nodes by default
![image](https://user-images.githubusercontent.com/3289485/71831503-a1f5d580-306e-11ea-8710-36235477fb0d.png)
- override website footer and add sales contact info
![image](https://user-images.githubusercontent.com/3289485/71831481-960a1380-306e-11ea-9359-022befa0bf41.png)
- add social sharing buttons/icons to content pages
![image](https://user-images.githubusercontent.com/3289485/71831452-8a1e5180-306e-11ea-9081-8ef52f2dfed2.png)
- rename "Resources" menu section header to "Archives"
![image](https://user-images.githubusercontent.com/3289485/71831425-7d016280-306e-11ea-9afc-f4bf25a7bc1d.png)
- redirect `/magazine` to `/magazine/:id` and update nav items to match
  - ensures that all magazines have the same "weight"
![image](https://user-images.githubusercontent.com/3289485/71831379-678c3880-306e-11ea-9c6e-ff3290497b86.png)
- migrate pullquote and blockquote styling from base/icarus css
![image](https://user-images.githubusercontent.com/3289485/71831342-4fb4b480-306e-11ea-9450-74af1fd49504.png)

