### PR TITLE
Fix spec guide min/max range formatting for sort and filter

### DIFF
--- a/packages/common/browser/spec-guide/table.vue
+++ b/packages/common/browser/spec-guide/table.vue
@@ -409,7 +409,6 @@ export default {
                 values.max = max;
                 values.hasRange = min !== max;
               } else {
-                console.log('range invalid', { lowKey, highKey, row });
                 values.min = 0;
                 values.max = 0;
                 values.hasRange = false;
@@ -424,7 +423,6 @@ export default {
                 values.max = max;
                 values.hasRange = min !== max;
               } else {
-                console.log('number invalid', { key, row });
                 values.min = 0;
                 values.max = 0;
                 values.hasRange = false;

--- a/packages/common/browser/spec-guide/table.vue
+++ b/packages/common/browser/spec-guide/table.vue
@@ -314,7 +314,7 @@ export default {
       const { key } = col;
       const value = get(row, key);
       if (!value) return '';
-      if (value.invalidNumber) return '';
+      if (value.invalidNumber) return value.raw || '';
       if (value.hasRange) return `${value.min} - ${value.max}`;
       if (value.min != null) return value.min;
       return value.raw;
@@ -385,8 +385,11 @@ export default {
             if (isArray(col.range) && col.range.length === 2) {
               // dependends on other spreadsheet fields for low/high values.
               const [lowKey, highKey] = col.range;
-              const lowRange = parseNumber({ value: this.getSourceValue(row, lowKey) });
-              const highRange = parseNumber({ value: this.getSourceValue(row, highKey) });
+              const lowRaw = this.getSourceValue(row, lowKey);
+              const highRaw = this.getSourceValue(row, highKey);
+
+              const lowRange = parseNumber({ value: lowRaw });
+              const highRange = parseNumber({ value: highRaw });
 
               if (lowRange && highRange) {
                 // both ranges were parsed successfully.
@@ -409,6 +412,7 @@ export default {
                 values.max = max;
                 values.hasRange = min !== max;
               } else {
+                values.raw = lowRaw || highRaw;
                 values.min = 0;
                 values.max = 0;
                 values.hasRange = false;

--- a/sites/oemoffhighway.com/config/spec-guides/motor.js
+++ b/sites/oemoffhighway.com/config/spec-guides/motor.js
@@ -96,12 +96,10 @@ module.exports = {
     in: {
       label: 'Output Shaft (in)',
       measure: 'standard',
-      type: 'number',
     },
     mm: {
       label: 'Output Shaft (mm)',
       measure: 'metric',
-      type: 'number',
     },
     productseries: {
       label: 'Product / Series',


### PR DESCRIPTION
- fix min/max range number formatting for dependent fields (resolves sort/filter issues)
- treat "Output Shaft" on OEM motor guide as a string (since individual numbers are entered into the spreadsheet)
- save the raw value of the field when a dependent range is invalid and use as display value (when present). as an example, this allows for displaying "Consult Factory" inside a number range.