### PR TITLE
Adjust node footers with max-width and right-aligned dates

### DIFF
--- a/packages/refresh-theme/scss/theme.scss
+++ b/packages/refresh-theme/scss/theme.scss
@@ -462,8 +462,8 @@ $theme-related-content-border-color: #dee2e6;
     text-transform: uppercase;
   }
 
-  &__footer {
-    justify-content: flex-start;
+  &__footer-left {
+    max-width: 70%;
   }
 
   &__footer-left:not(:empty) + &__footer-right {


### PR DESCRIPTION
- Set `max-width: 70%;` to `node__footer-left`
- Remove `justify-content: flex-start;` from `node__footer`

Current:
![image](https://user-images.githubusercontent.com/3289485/73691875-d58d4500-4698-11ea-8617-1fcb53eec11b.png)
![image](https://user-images.githubusercontent.com/3289485/73692017-1f762b00-4699-11ea-90cf-7812ea6084a8.png)


New:
![image](https://user-images.githubusercontent.com/3289485/73691986-108f7880-4699-11ea-8e49-421803ddf1cd.png)
![image](https://user-images.githubusercontent.com/3289485/73692032-2735cf80-4699-11ea-9389-e59d231671c3.png)

