### PR TITLE
Ensure dates stay right-aligned when no author is present

### DIFF
--- a/packages/refresh-theme/scss/theme.scss
+++ b/packages/refresh-theme/scss/theme.scss
@@ -467,6 +467,13 @@ $theme-related-content-border-color: #dee2e6;
     text-transform: uppercase;
   }
 
+  &__footer-left,
+  &__footer-right {
+    &:empty {
+      display: block;
+    }
+  }
+
   &__footer-left {
     max-width: 70%;
   }


### PR DESCRIPTION
Footer elements will now display when empty. This ensures that the left / right positioning of each footer element stays intact when one is empty. In other words, dates will now stay right-aligned when no author is present.

![image](https://user-images.githubusercontent.com/3289485/74155140-9fd8e680-4bd9-11ea-97d4-b64b840998a1.png)

![image](https://user-images.githubusercontent.com/3289485/74155159-acf5d580-4bd9-11ea-8f07-d254a751455a.png)

[Jira Request](https://southcomm.atlassian.net/browse/BCMS-376?atlOrigin=eyJpIjoiY2RiODhhYzgyOWFhNDdkZTk1ZmFhNjhhNzU2NTZkODIiLCJwIjoiaiJ9)