### PR TITLE
Fix typo in "Whitepapers & Ebooks" link on Media Center page

### DIFF
--- a/sites/oemoffhighway.com/server/templates/website-section/media-center.marko
+++ b/sites/oemoffhighway.com/server/templates/website-section/media-center.marko
@@ -69,7 +69,7 @@ $ const adSlots = ({ aliases }) => ({
         </@section>
         <@section>
           <refresh-theme-media-center-section-block title="White Papers & Ebooks">
-            <@link href="/media-center/whitepapers-ebook" />
+            <@link href="/media-center/whitepapers-ebooks" />
             <@query name="all-published-content" params={ limit: 6, includeContentTypes: ["Whitepaper", "Ebook"], queryFragment } />
           </refresh-theme-media-center-section-block>
         </@section>


### PR DESCRIPTION
- fix the link to point to `/media-center/whitepapers-ebooks`

[Jira Issue](https://southcomm.atlassian.net/browse/BCMS-406?atlOrigin=eyJpIjoiYmMyZDc5ZjNhNzY3NDA4M2ExOWZlMzNkZGY2YWQyOTEiLCJwIjoiaiJ9)