### PR TITLE
Update SDCE & FL navigation

### DIFF
--- a/sites/foodlogistics.com/config/navigation.js
+++ b/sites/foodlogistics.com/config/navigation.js
@@ -17,6 +17,7 @@ module.exports = {
       { href: '/magazine', label: 'Magazine' },
       { href: '/awards', label: 'Awards' },
       { href: '/events', label: 'Events' },
+      { href: '/blogs', label: 'Expert Columnists' },
       { href: 'https://www.supplychainnetworkmediakit.com/', label: 'Advertise', target: '_blank' },
       { href: '/contact-us', label: 'Contact Us' },
       { href: '/webinars', label: 'Webinars' },

--- a/sites/sdcexec.com/config/navigation.js
+++ b/sites/sdcexec.com/config/navigation.js
@@ -15,6 +15,8 @@ module.exports = {
     items: [
       { href: '/magazine', label: 'Magazine' },
       { href: '/awards', label: 'Awards' },
+      { href: '/events', label: 'Events' },
+      { href: '/blogs', label: 'Expert Columnists' },
       { href: 'http://www.supplychainnetworkmediakit.com/', label: 'Advertise', target: '_blank' },
       { href: '/contact-us', label: 'Contact Us' },
       { href: '/webinars', label: 'Webinars' },


### PR DESCRIPTION
Ref [BCMS-455](https://southcomm.atlassian.net/browse/BCMS-455)

- SDC: Add ‘events’ to the secondary navigation. Place it between ‘awards’ and ‘advertise’. 
- SDC & FLOG: add ‘Expert Columns’ to the secondary navigation. Place it between ‘events’ and ‘advertise’.