### PR TITLE
Drop automatic inclusion of primary image on video pages

### DIFF
--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -12,7 +12,7 @@ $ const adSlots = ({ aliases }) => ({
   "gpt-ad-rail2": GAM.getAdUnit({ name: "rail2", aliases }),
   "gpt-ad-rail-infinite": GAM.getAdUnit({ name: "infinite-rail", aliases }),
 });
-$ const displayPrimaryImage = ["whitepaper", "media-gallery"].includes(type) ? false : true;
+$ const displayPrimaryImage = ["whitepaper", "media-gallery", "video"].includes(type) ? false : true;
 $ const displayPublishedDate = ["event", "webinar", "company", "contact"].includes(type) ? false : true;
 $ const displayRecommended = ["company", "product", "contact"].includes(type) ? false : true;
 $ const displayInquiry = (content) => {


### PR DESCRIPTION
### Before:
![Screen Shot 2020-03-04 at 7 13 57 AM](https://user-images.githubusercontent.com/2855198/75883036-f6f06680-5de7-11ea-910d-add0f2a410f3.png)

### After:
![Screen Shot 2020-03-04 at 7 12 53 AM](https://user-images.githubusercontent.com/2855198/75883045-f8ba2a00-5de7-11ea-988d-1e26eac39d89.png)
