### PR TITLE
Add Podcast links to site menu

### DIFF
--- a/sites/foodlogistics.com/config/navigation.js
+++ b/sites/foodlogistics.com/config/navigation.js
@@ -81,6 +81,7 @@ module.exports = {
         { href: '/blogs', label: 'Expert Columnists' },
         { href: '/case-studies', label: 'Case Studies' },
         { href: '/modex', label: 'MODEX' },
+        { href: '/podcasts', label: 'Podcasts' },
         { href: '/events', label: 'Events' },
         { href: 'https://www.supplychainnetworkmediakit.com/', label: 'Advertise', target: '_blank' },
         { href: '/contact-us', label: 'Contact Us' },

--- a/sites/sdcexec.com/config/navigation.js
+++ b/sites/sdcexec.com/config/navigation.js
@@ -78,6 +78,7 @@ module.exports = {
         { href: 'https://sdcexec.tradepub.com/?pt=dir&page=sdcexec', label: 'Sponsored Research', target: '_blank' },
         { href: '/case-studies', label: 'Case Studies' },
         { href: '/modex', label: 'MODEX' },
+        { href: '/podcast', label: 'Podcasts' },
         { href: '/events', label: 'Events' },
         { href: '/webinars', label: 'Webinars' },
         { href: 'http://www.supplychainlearningcenter.com/', label: 'Learning Center', target: '_blank' },


### PR DESCRIPTION
Ref [BCMS-598](https://southcomm.atlassian.net/browse/BCMS-598)

Please add the Podcast page to FLOG's menu. Here's the link: https://www.foodlogistics.com/podcasts

And, please do the same for SDCE's menu. Here's the link: https://www.sdcexec.com/podcast