### PR TITLE
Ensure Podcast pages pull section description and logo

### DIFF
--- a/packages/refresh-theme/components/layouts/website-section-published-content.marko
+++ b/packages/refresh-theme/components/layouts/website-section-published-content.marko
@@ -59,9 +59,15 @@ $ delete loadMoreParams.queryFragment;
         </@section>
         <@section>
           <div class="row">
-            <div class="col">
+            <div class="col-lg-8">
               <marko-web-website-section-name tag="h1" class="page-wrapper__title" obj=section />
               <marko-web-website-section-description class="page-wrapper__deck" obj=section />
+            </div>
+            <div class="col-lg-4">
+              <marko-web-page-image
+                obj={ src: resolved.get("logo.src"), alt: `${name} Logo` }
+                fluid=true
+              />
             </div>
           </div>
         </@section>

--- a/packages/refresh-theme/graphql/fragments/website-section-page.js
+++ b/packages/refresh-theme/graphql/fragments/website-section-page.js
@@ -10,5 +10,9 @@ fragment WebsiteSectionPageFragment on WebsiteSection {
     alias
     name
   }
+  logo {
+    id
+    src
+  }
 }
 `;


### PR DESCRIPTION
Ref [BCMS-600](https://southcomm.atlassian.net/browse/BCMS-600)

Original message:

Hello,
In the podcast pages for both FLOG and SDCE, the top description is supposed to say:

Learn, Innovate, News, Knowledge. Your L.I.N.K. to Global Supply Chain Intelligence

Would also love to get the attached logo placed on as well, for both pages. Thanks.

![LINK logo](https://user-images.githubusercontent.com/3289485/79871241-b05fc700-83a9-11ea-87f4-b294d4246a99.png)
