### PR TITLE
Add newsletter subscribe link to secondary nav

### DIFF
--- a/sites/mixequipmentmag.com/config/navigation.js
+++ b/sites/mixequipmentmag.com/config/navigation.js
@@ -12,6 +12,12 @@ module.exports = {
   secondary: {
     items: [
       { href: '/magazine/5dea77962231ca27128b45f9', label: 'Magazine' },
+      {
+        href: '/page/subscribe/newsletter',
+        label: 'Newsletter',
+        icon: 'mail',
+        forceLabel: true,
+      },
     ],
   },
   tertiary: {


### PR DESCRIPTION
Ref [BCMS-601](https://southcomm.atlassian.net/browse/BCMS-601)

Original message:

https://manage.mixequipmentmag.com/content/edit/page/21125087 

Please add ‘newsletter’ to the top navigation (next to magazine) and link it to the page above. Include the logo we used on foodlogistics:  