### PR TITLE
Section logos and navigation updates

### DIFF
--- a/packages/refresh-theme/components/content-section-logo.marko
+++ b/packages/refresh-theme/components/content-section-logo.marko
@@ -1,0 +1,22 @@
+import { getAsArray, getAsObject, get } from "@base-cms/object-path";
+
+$ const section = getAsObject(input, "section");
+$ const hierarchy = getAsArray(section, "hierarchy");
+
+$ let logo;
+$ for (let i = 0; i < hierarchy.length; i += 1) {
+  if (logo) break;
+  const item = hierarchy[i];
+  if (get(item, "logo.src")) logo = get(item, "logo");
+}
+
+<if(logo)>
+  $ const obj = { ...logo, alt: `${section.name} Logo` };
+  <marko-web-page-image
+    width=150
+    fluid=false
+    modifiers=["section-logo"]
+    ...input.image
+    obj=obj
+  />
+</if>

--- a/packages/refresh-theme/components/marko.json
+++ b/packages/refresh-theme/components/marko.json
@@ -28,5 +28,13 @@
   },
   "<refresh-theme-contextual-header>": {
     "template": "./site-header/contextual.marko"
+  },
+  "<refresh-theme-content-section-logo>": {
+    "template": "./content-section-logo.marko",
+    "<section>": {
+      "@name": "string",
+      "@hierarchy": "array"
+    },
+    "<image>": {}
   }
 }

--- a/packages/refresh-theme/components/site-header/contextual.marko
+++ b/packages/refresh-theme/components/site-header/contextual.marko
@@ -1,19 +1,25 @@
 import isActiveLink from "@base-cms/marko-web-theme-default/components/site-navbar/utils/is-active-link";
+import { getAsArray } from "@base-cms/object-path";
 import { asArray } from "@base-cms/utils";
 
 $ const { config, site, req } = out.global;
 
 $ const blockName = input.blockName || "site-header";
 
-$ const navigation = {
-  primary: site.getAsArray("navigation.primary.items"),
-  secondary: site.getAsArray("navigation.secondary.items"),
-  tertiary: site.getAsArray("navigation.tertiary.items"),
-  contextual: site.getAsArray("navigation.contextual.items"),
-  menu: site.getAsArray("navigation.menu"),
+$ const contexts = site.getAsArray("navigation.contexts");
+$ const contextualNav = contexts.find(({ when }) => asArray(when).some(path => isActiveLink(req.path, path)));
+
+$ const getNavItems = (key) => {
+  if (!contextualNav) return  site.getAsArray(`navigation.${key}`);
+  return getAsArray(contextualNav, key);
 };
 
-$ const contextualItem = navigation.contextual.find(({ when }) => asArray(when).some(path => isActiveLink(req.path, path)));
+$ const navigation = {
+  primary: getNavItems("primary.items"),
+  secondary: getNavItems("secondary.items"),
+  tertiary: getNavItems("tertiary.items"),
+  menu: site.getAsArray("navigation.menu"),
+};
 
 <marko-web-block
   name=blockName
@@ -40,7 +46,7 @@ $ const contextualItem = navigation.contextual.find(({ when }) => asArray(when).
       />
     </default-theme-site-navbar-brand>
     <default-theme-site-navbar-items
-      items=(contextualItem ? navigation.primary : navigation.secondary)
+      items=navigation.secondary
       modifiers=["secondary"]
       reg-enabled=input.regEnabled
       has-user=input.hasUser
@@ -56,7 +62,7 @@ $ const contextualItem = navigation.contextual.find(({ when }) => asArray(when).
 
   <default-theme-site-navbar modifiers=["primary"]>
     <default-theme-site-navbar-items
-      items=(contextualItem ? contextualItem.items : navigation.primary)
+      items=navigation.primary
       modifiers=["primary"]
       reg-enabled=input.regEnabled
       has-user=input.hasUser

--- a/packages/refresh-theme/graphql/fragments/content-page.js
+++ b/packages/refresh-theme/graphql/fragments/content-page.js
@@ -37,6 +37,10 @@ fragment ContentPageFragment on Content {
       name
       alias
       canonicalPath
+      logo {
+        id
+        src
+      }
     }
   }
   primaryImage {

--- a/packages/refresh-theme/scss/theme.scss
+++ b/packages/refresh-theme/scss/theme.scss
@@ -408,6 +408,10 @@ $theme-related-content-border-color: #dee2e6;
     margin-top: 0;
   }
 
+  &--section-logo {
+    margin-top: $marko-web-page-image-margin;
+  }
+
   // @todo keep in skin
   > :last-child:not(#{ $self }__wrapper) {
     border-bottom: none;

--- a/packages/refresh-theme/scss/theme.scss
+++ b/packages/refresh-theme/scss/theme.scss
@@ -362,6 +362,14 @@ $theme-related-content-border-color: #dee2e6;
     color: $primary;
   }
 
+  > div {
+    margin-left: .25rem;
+  }
+
+  > div:first-child {
+    margin-left: 0;
+  }
+
   div:last-child {
     margin-bottom: 0;
   }

--- a/packages/refresh-theme/templates/content/index.marko
+++ b/packages/refresh-theme/templates/content/index.marko
@@ -86,6 +86,10 @@ $ const injectAds = ["article", "news", "press-release", "blog"].includes(type) 
                 <default-theme-content-attribution obj=content />
               </div>
 
+              <refresh-theme-content-section-logo>
+                <@section name=section.name hierarchy=section.hierarchy />
+              </refresh-theme-content-section-logo>
+
               <if(displaySocialShare)>
                 <marko-web-social-sharing
                   path=content.siteContext.path

--- a/sites/forconstructionpros.com/config/navigation.js
+++ b/sites/forconstructionpros.com/config/navigation.js
@@ -19,14 +19,33 @@ const resources = [
   { href: 'https://www.constructionnetworkmediakit.com/', label: 'Advertise', target: '_blank' },
 ];
 
-module.exports = {
-  primary: {
-    items: channels,
+const tertiaryItems = [
+  {
+    href: 'https://acbusiness.dragonforms.com/loading.do?omedasite=FCP_prefs_ProgReg',
+    label: 'Sign Up',
+    icon: 'mail',
+    forceLabel: true,
+    target: '_blank',
   },
-  contextual: {
-    items: [
-      {
-        when: ['/equipment', '/trucks'],
+  {
+    href: '/search',
+    label: 'Search',
+    icon: 'search',
+    forceLabel: true,
+  },
+];
+
+module.exports = {
+  secondary: { items: channels },
+  primary: { items: resources },
+  tertiary: { items: tertiaryItems },
+
+  contexts: [
+    {
+      when: ['/equipment', '/trucks'],
+      secondary: { items: channels },
+      tertiary: { items: tertiaryItems },
+      primary: {
         items: [
           { href: '/trucks', label: 'Trucks' },
           { href: '/equipment/earthmoving', label: 'Earthmoving' },
@@ -35,8 +54,12 @@ module.exports = {
           { href: '/equipment/compaction', label: 'Compaction' },
         ],
       },
-      {
-        when: ['/rental'],
+    },
+    {
+      when: ['/rental'],
+      secondary: { items: channels },
+      tertiary: { items: tertiaryItems },
+      primary: {
         items: [
           { href: '/rental/lifting-equipment', label: 'Lifting' },
           { href: '/rental/lifting-equipment/telescopic-handler', label: 'Telescopic Lifts' },
@@ -45,8 +68,12 @@ module.exports = {
           { href: '/rental/inventory', label: 'Inventory' },
         ],
       },
-      {
-        when: ['/concrete'],
+    },
+    {
+      when: ['/concrete'],
+      secondary: { items: channels },
+      tertiary: { items: tertiaryItems },
+      primary: {
         items: [
           { href: '/concrete/decorative', label: 'Decorative' },
           { href: '/concrete/equipment-products', label: 'Equipment & Products' },
@@ -55,8 +82,12 @@ module.exports = {
           { href: '/concrete/equipment-products/repair-rehabilitation-products', label: 'Repair' },
         ],
       },
-      {
-        when: ['/asphalt'],
+    },
+    {
+      when: ['/asphalt'],
+      secondary: { items: channels },
+      tertiary: { items: tertiaryItems },
+      primary: {
         items: [
           { href: '/asphalt/additives', label: 'Additives' },
           { href: '/asphalt/plants', label: 'Plants' },
@@ -65,8 +96,12 @@ module.exports = {
           { href: '/asphalt/material-transfer-vehicles', label: 'Vehicles' },
         ],
       },
-      {
-        when: ['/business'],
+    },
+    {
+      when: ['/business'],
+      secondary: { items: channels },
+      tertiary: { items: tertiaryItems },
+      primary: {
         items: [
           { href: '/business/business-services', label: 'Services' },
           { href: '/business/construction-safety', label: 'Safety' },
@@ -74,8 +109,12 @@ module.exports = {
           { href: '/business/labor-workforce-development', label: 'Labor' },
         ],
       },
-      {
-        when: ['/construction-technology'],
+    },
+    {
+      when: ['/construction-technology'],
+      secondary: { items: channels },
+      tertiary: { items: tertiaryItems },
+      primary: {
         items: [
           { href: '/construction-technology/apps', label: 'Apps' },
           { href: '/construction-technology/theft-prevention', label: 'Theft Prevention' },
@@ -84,36 +123,21 @@ module.exports = {
           { href: '/construction-technology/machine-grade-control-gps-laser-other', label: 'Machine Grade Control, GPS, Laser & Other' },
         ],
       },
-      {
-        when: ['/pavement-maintenance'],
+    },
+    {
+      when: ['/pavement-maintenance'],
+      secondary: { items: channels },
+      tertiary: { items: tertiaryItems },
+      primary: {
         items: [
           { href: '/pavement-maintenance/sweepers', label: 'Sweepers' },
           { href: '/pavement-maintenance/marking-striping', label: 'Marking & Striping' },
           { href: '/pavement-maintenance/preservation-maintenance', label: 'Preservation' },
         ],
       },
-    ],
-  },
-  secondary: {
-    items: resources,
-  },
-  tertiary: {
-    items: [
-      {
-        href: 'https://acbusiness.dragonforms.com/loading.do?omedasite=FCP_prefs_ProgReg',
-        label: 'Sign Up',
-        icon: 'mail',
-        forceLabel: true,
-        target: '_blank',
-      },
-      {
-        href: '/search',
-        label: 'Search',
-        icon: 'search',
-        forceLabel: true,
-      },
-    ],
-  },
+    },
+  ],
+
   footer: {
     items: [
       { href: '/contact-us', label: 'Contact Us' },

--- a/sites/forconstructionpros.com/server/styles/index.scss
+++ b/sites/forconstructionpros.com/server/styles/index.scss
@@ -11,8 +11,8 @@ $theme-site-navbar-logo-height: 45px;
 $theme-site-navbar-logo-height-sm: 30px;
 
 $theme-site-header-breakpoints: (
-  hide-primary: 854px,
-  hide-secondary: 1078px,
+  hide-primary: 780px,
+  hide-secondary: 1057px,
   small-logo: 375px,
   small-text-primary: 0,
   small-text-secondary: 0
@@ -29,6 +29,12 @@ $website-section-colors: (
   profit-matters: #e9a422,
   equipment-management: #98002e,
 );
+
+$theme-site-navbar-primary-font-size: 14px !default;
+$theme-site-navbar-primary-font-size-sm: 14px !default;
+
+$theme-site-navbar-secondary-font-size: 16px !default;
+$theme-site-navbar-secondary-font-size-sm: 16px !default;
 
 @import "../../node_modules/@ac-business-media/refresh-theme/scss/theme";
 
@@ -82,9 +88,18 @@ $website-section-colors: (
 }
 
 .site-navbar {
+  $self: &;
   &__items {
     &--primary {
       width: auto;
+      #{ $self } {
+        &__item {
+          padding: 8px 12px;
+        }
+      }
+    }
+    &--tertiary {
+      font-size: 13px;
     }
   }
 }


### PR DESCRIPTION
- On the homepage, can you move CHANNELS to the top navigation and move the other items (new equipment directory, spec guides, etc) to below the channels?  On content pages the channels are at the top already, let’s keep it consistent. 
- Make the CHANNEL list larger font to give it priority over sub-channels. 
- Finally – add more padding between subchannels. 
- Add brand logos on content pages when they appears in a coordinating channel

![image](https://user-images.githubusercontent.com/3289485/80000565-e91f9f00-8482-11ea-96c1-0171be3825fc.png)
