### PR TITLE
Add missing source { width, height } params

### DIFF
--- a/packages/refresh-theme/graphql/fragments/content-page.js
+++ b/packages/refresh-theme/graphql/fragments/content-page.js
@@ -159,6 +159,10 @@ fragment ContentPageFragment on Content {
         id
         src
         alt
+        source {
+          width
+          height
+        }
         displayName
         caption
         credit


### PR DESCRIPTION
The source width & height where missing so it was always cropping to 16 x 9 & not respecting the actual dimensions.

![Screen Shot 2020-05-04 at 11 53 39 AM](https://user-images.githubusercontent.com/3845869/80991653-f8e1a080-8dfd-11ea-98a3-7be8df4af06a.png)
