### PR TITLE
Removed IFPE & CONEXPO from nav

### DIFF
--- a/sites/oemoffhighway.com/config/navigation.js
+++ b/sites/oemoffhighway.com/config/navigation.js
@@ -7,7 +7,6 @@ module.exports = {
       { href: '/electronics', label: 'Electronics' },
       { href: '/operator-cab', label: 'Operator Cab' },
       { href: '/engineering-manufacturing', label: 'Engineering & Manufacturing' },
-      { href: '/ifpe-conexpo', label: 'IFPE & CONEXPO' },
     ],
   },
   secondary: {


### PR DESCRIPTION
Updated nav:
![Screen Shot 2020-05-13 at 2 33 58 PM](https://user-images.githubusercontent.com/12496550/81856885-0b0ebd80-9527-11ea-9832-51fd951c23d4.png)
