### PR TITLE
Increase navigation breakpoints; remove Magazine and Podcasts

### DIFF
--- a/sites/sdcexec.com/config/navigation.js
+++ b/sites/sdcexec.com/config/navigation.js
@@ -14,7 +14,6 @@ module.exports = {
   },
   secondary: {
     items: [
-      { href: '/magazine', label: 'Magazine' },
       { href: '/awards', label: 'Awards' },
       { href: '/events', label: 'Events' },
       { href: '/blogs', label: 'Expert Columnists' },

--- a/sites/sdcexec.com/config/navigation.js
+++ b/sites/sdcexec.com/config/navigation.js
@@ -78,7 +78,6 @@ module.exports = {
         { href: 'https://sdcexec.tradepub.com/?pt=dir&page=sdcexec', label: 'Sponsored Research', target: '_blank' },
         { href: '/case-studies', label: 'Case Studies' },
         { href: '/modex', label: 'MODEX' },
-        { href: '/podcast', label: 'Podcasts' },
         { href: '/events', label: 'Events' },
         { href: '/webinars', label: 'Webinars' },
         { href: 'http://www.supplychainlearningcenter.com/', label: 'Learning Center', target: '_blank' },

--- a/sites/sdcexec.com/server/styles/index.scss
+++ b/sites/sdcexec.com/server/styles/index.scss
@@ -11,8 +11,8 @@ $theme-site-navbar-logo-height: 45px;
 $theme-site-navbar-logo-height-sm: 30px;
 
 $theme-site-header-breakpoints: (
-  hide-primary: 854px,
-  hide-secondary: 1078px,
+  hide-primary: 950px,
+  hide-secondary: 1210px,
   small-logo: 375px,
   small-text-primary: 0,
   small-text-secondary: 0


### PR DESCRIPTION
At the request of Gabbie via https://southcomm.atlassian.net/browse/BCMS-688
- Removed "Magazine" from secondary nav
- Removed duplicate "Podcasts" from menu

New breakpoint for secondary nav:
![Screen Shot 2020-05-20 at 12 43 17 PM](https://user-images.githubusercontent.com/12496550/82479601-38fc8080-9a98-11ea-842d-124ea9fec94a.png)

New breakpoint for primary nav:
![Screen Shot 2020-05-20 at 12 42 59 PM](https://user-images.githubusercontent.com/12496550/82479612-3dc13480-9a98-11ea-84da-f4f097306341.png)