### PR TITLE
Enable Leaders for FL, add home page block to refresh theme

### DIFF
--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -1,8 +1,9 @@
 import hierarchyAliases from "@base-cms/marko-web/utils/hierarchy-aliases";
+import { get } from "@base-cms/object-path";
 import queryFragment from "../graphql/fragments/content-list";
 import latestQueryFragment from "../graphql/fragments/content-latest";
 
-$ const { GAM } = out.global;
+$ const { site, GAM } = out.global;
 
 $ const {
   id,
@@ -16,6 +17,8 @@ $ const excludeContentTypes = [
   "Contact",
   "Promotion",
 ];
+
+$ const displayLeaders = site.get("leaders.enabled") ? true : false;
 
 $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
@@ -95,6 +98,19 @@ $ const adSlots = ({ aliases }) => ({
             </div>
           </div>
         </@section>
+
+        <if(displayLeaders)>
+          <@section>
+            <div class="row">
+              <div class="col-lg-8 mb-block">
+                <leaders-home-page />
+              </div>
+              <div class="col-lg-4 mb-block">
+                <!-- @todo Add eNL signup block -->
+              </div>
+            </div>
+          </@section>
+        </if>
 
         <@section>
           <div class="row">

--- a/packages/refresh-theme/templates/index.marko
+++ b/packages/refresh-theme/templates/index.marko
@@ -18,8 +18,6 @@ $ const excludeContentTypes = [
   "Promotion",
 ];
 
-$ const displayLeaders = site.get("leaders.enabled") ? true : false;
-
 $ const adSlots = ({ aliases }) => ({
   "gpt-ad-lb1": GAM.getAdUnit({ name: "lb1", aliases }),
   "gpt-ad-lb2": GAM.getAdUnit({ name: "lb1", aliases }),
@@ -99,7 +97,7 @@ $ const adSlots = ({ aliases }) => ({
           </div>
         </@section>
 
-        <if(displayLeaders)>
+        <if(site.get("leaders.enabled"))>
           <@section>
             <div class="row">
               <div class="col-lg-8 mb-block">

--- a/sites/foodlogistics.com/config/site.js
+++ b/sites/foodlogistics.com/config/site.js
@@ -64,4 +64,13 @@ module.exports = {
     logo: 'https://img.foodlogistics.com/files/base/acbm/fl/image/static/logo/site_logo_large.png?h=60',
     bgColor: '#1a93f9',
   },
+  leaders: {
+    enabled: true,
+    title: 'Food Logistics Leaders',
+    alias: 'leaders/2020',
+    calloutValue: 'Leading Providers',
+    header: {
+      imgSrc: 'https://img.foodlogistics.com/files/base/acbm/sdce/image/static/sdc-leaders.png?h=85',
+    },
+  },
 };

--- a/sites/foodlogistics.com/server/styles/index.scss
+++ b/sites/foodlogistics.com/server/styles/index.scss
@@ -29,4 +29,8 @@ $website-section-colors: (
   "3pl-4pl": #667984,
 );
 
+$leaders-primary-color: #212121;
+$leaders-primary-color-light: lighten($leaders-primary-color, 10%);
+$leaders-accent-color: #212121;
+
 @import "../../node_modules/@ac-business-media/refresh-theme/scss/theme";


### PR DESCRIPTION
Note it is properly collapsing for FCP, who doesn't yet have Leaders.  Verified on SDC as well.

The empty whitespace to the right of the home page block is still being discussed.

![Screen Shot 2020-05-28 at 2 51 10 PM](https://user-images.githubusercontent.com/2855198/83186981-01728180-a0f3-11ea-906d-2f2c281f29d8.png)
![Screen Shot 2020-05-28 at 2 51 22 PM](https://user-images.githubusercontent.com/2855198/83186982-03d4db80-a0f3-11ea-9fdf-f17b2250436c.png)
