### PR TITLE
Drop “Learing Center”, add “Magazine” to SDC secondary nav

### DIFF
--- a/sites/sdcexec.com/config/navigation.js
+++ b/sites/sdcexec.com/config/navigation.js
@@ -14,13 +14,13 @@ module.exports = {
   },
   secondary: {
     items: [
+      { href: '/magazine', label: 'Magazine' },
       { href: '/awards', label: 'Awards' },
       { href: '/events', label: 'Events' },
       { href: '/blogs', label: 'Expert Columnists' },
       { href: 'http://www.supplychainnetworkmediakit.com/', label: 'Advertise', target: '_blank' },
       { href: '/contact-us', label: 'Contact Us' },
       { href: '/webinars', label: 'Webinars' },
-      { href: 'http://www.supplychainlearningcenter.com/', label: 'Learning Center', target: '_blank' },
       { href: 'https://sdcexec.tradepub.com/?pt=dir&page=sdcexec', label: 'Sponsored Research', target: '_blank' },
     ],
   },


### PR DESCRIPTION
![Screen Shot 2020-06-03 at 1 39 18 PM](https://user-images.githubusercontent.com/2855198/83676115-cadbb180-a59f-11ea-9934-01cb8932ba6f.png)
